### PR TITLE
fix: catch Multiplexer is destroyed error into callback

### DIFF
--- a/src/muxer.js
+++ b/src/muxer.js
@@ -51,7 +51,12 @@ class MultiplexMuxer extends EventEmitter {
   // method added to enable pure stream muxer feeling
   newStream (callback) {
     callback = callback || noop
-    let stream = this.multiplex.createStream()
+    let stream
+    try {
+      stream = this.multiplex.createStream()
+    } catch (err) {
+      return callback(err)
+    }
 
     const conn = new Connection(
       catchError(toPull.duplex(stream)),

--- a/test/muxer.spec.js
+++ b/test/muxer.spec.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+
+const EventEmitter = require('events')
+const pair = require('pull-pair/duplex')
+
+const Muxer = require('../src/muxer')
+
+describe('multiplex-muxer', () => {
+  let muxer
+  let multiplex
+
+  it('can be created', () => {
+    const p = pair()
+    multiplex = new EventEmitter()
+    muxer = new Muxer(p, multiplex)
+  })
+
+  it('catches newStream errors', (done) => {
+    multiplex.createStream = () => {
+      throw new Error('something nbad happened')
+    }
+    muxer.newStream((err) => {
+      expect(err).to.exist()
+      expect(err.message).to.equal('something nbad happened')
+      done()
+    })
+  })
+
+  it('can get destroyed', (done) => {
+    let destroyed = false
+    multiplex.destroy = () => {
+      destroyed = true
+      setImmediate(() => multiplex.emit('close'))
+    }
+
+    muxer.end((err) => {
+      expect(err).to.not.exist()
+      expect(destroyed).to.be.true()
+      done()
+    })
+  })
+})


### PR DESCRIPTION
This prevents uncaught "Multiplexer is destroyed" exceptions from being thrown into the void.