### PR TITLE
fix: verify drain before new push

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-mplex#readme",
   "devDependencies": {
-    "aegir": "^14.0.0",
+    "aegir": "^15.2.0",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
     "interface-stream-muxer": "~0.5.9",

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -164,7 +164,7 @@ class Multiplex extends stream.Duplex {
       used = 0
     }
 
-    if (data) {
+    if (data && drained) {
       drained = this.push(data)
     }
 


### PR DESCRIPTION
In the context of failing CI issues in [js-libp2p-kad-dht/pull/42](https://github.com/libp2p/js-libp2p-kad-dht/pull/42), a verification of `drained` was added.