### PR TITLE
fix: improve resiliency of internals _send

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "homepage": "https://github.com/libp2p/js-libp2p-mplex#readme",
   "devDependencies": {
     "aegir": "^15.2.0",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "interface-stream-muxer": "~0.5.9",
-    "libp2p-tcp": "~0.12.0",
+    "libp2p-tcp": "~0.13.0",
     "libp2p-websockets": "~0.12.0",
     "pull-pair": "^1.1.0"
   },
@@ -45,10 +45,10 @@
     "duplexify": "^3.6.0",
     "interface-connection": "~0.3.2",
     "pull-catch": "^1.0.0",
-    "pull-stream": "^3.6.8",
+    "pull-stream": "^3.6.9",
     "pull-stream-to-stream": "^1.3.4",
     "pump": "^3.0.0",
-    "readable-stream": "^2.3.6",
+    "readable-stream": "^3.0.3",
     "stream-to-pull-stream": "^1.7.2",
     "through2": "^2.0.3",
     "varint": "^5.0.0"


### PR DESCRIPTION
* This also updates dependencies to the latest

The js-libp2p tests exposed an issue with the latest of libp2p-mplex, where because `Multiplex._send()` is potentially doing 2 pushed, we can get into a bad state where `readable.push()` returns false, but we still have data to give. This could result in streams not closing properly, which was happening in the libp2p tests that exposed the issue.

This PR concatenates the varint and data pushes (if there is data) into a single push. This avoids the scenario of there being residual data to send when `.push` returns false.

You can see the passing build of libp2p using this branch here: https://ci.ipfs.team/blue/organizations/jenkins/libp2p%2Fjs-libp2p/detail/test%2Fgoodbye-mplex/2/pipeline