### PR TITLE
fix: muxer.end will no longer hang

### DIFF
--- a/src/muxer.js
+++ b/src/muxer.js
@@ -70,8 +70,8 @@ class MultiplexMuxer extends EventEmitter {
 
   end (callback) {
     callback = callback || noop
-    this.multiplex.once('close', callback)
     this.multiplex.destroy()
+    callback()
   }
 }
 

--- a/test/muxer.spec.js
+++ b/test/muxer.spec.js
@@ -6,10 +6,10 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
-const EventEmitter = require('events')
 const pair = require('pull-pair/duplex')
 
 const Muxer = require('../src/muxer')
+const Multiplex = require('../src/internals')
 
 describe('multiplex-muxer', () => {
   let muxer
@@ -17,7 +17,7 @@ describe('multiplex-muxer', () => {
 
   it('can be created', () => {
     const p = pair()
-    multiplex = new EventEmitter()
+    multiplex = new Multiplex()
     muxer = new Muxer(p, multiplex)
   })
 
@@ -33,15 +33,21 @@ describe('multiplex-muxer', () => {
   })
 
   it('can get destroyed', (done) => {
-    let destroyed = false
-    multiplex.destroy = () => {
-      destroyed = true
-      setImmediate(() => multiplex.emit('close'))
-    }
+    expect(multiplex.destroyed).to.eql(false)
 
     muxer.end((err) => {
       expect(err).to.not.exist()
-      expect(destroyed).to.be.true()
+      expect(multiplex.destroyed).to.be.true()
+      done()
+    })
+  })
+
+  it('should handle a repeat destroy', (done) => {
+    expect(multiplex.destroyed).to.be.true()
+
+    muxer.end((err) => {
+      expect(err).to.not.exist()
+      expect(multiplex.destroyed).to.be.true()
       done()
     })
   })


### PR DESCRIPTION
`muxer.end` was previously waiting for the 'close' event before calling its callback. If the stream was already destroyed, close would not be triggered and the callback would never be called.

Since close is emitted synchronously in the `multiplex.destroy` method there is no need to bind a listener and we can execute the callback immediately following the destroy.

This will also avoid leaking event listeners on end, and the accompanying warning when numerous muxers are closed simultaneously. 