### PR TITLE
Improve error handling

### DIFF
--- a/examples/dialer.js
+++ b/examples/dialer.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict'
 
 const tcp = require('net')

--- a/examples/listener.js
+++ b/examples/listener.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict'
 
 const tcp = require('net')

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "aegir": "^15.2.0",
     "chai": "^4.2.0",
+    "chai-checkmark": "^1.0.1",
     "dirty-chai": "^2.0.1",
     "interface-stream-muxer": "~0.5.9",
     "libp2p-tcp": "~0.13.0",

--- a/package.json
+++ b/package.json
@@ -29,29 +29,29 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-mplex#readme",
   "devDependencies": {
-    "aegir": "^15.2.0",
+    "aegir": "^17.0.1",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "dirty-chai": "^2.0.1",
     "interface-stream-muxer": "~0.5.9",
     "libp2p-tcp": "~0.13.0",
     "libp2p-websockets": "~0.12.0",
-    "pull-pair": "^1.1.0"
+    "pull-pair": "^1.1.0",
+    "through2": "^2.0.3"
   },
   "dependencies": {
     "async": "^2.6.1",
     "chunky": "0.0.0",
     "concat-stream": "^1.6.2",
-    "debug": "^3.1.0",
+    "debug": "^4.1.0",
     "duplexify": "^3.6.0",
     "interface-connection": "~0.3.2",
     "pull-catch": "^1.0.0",
     "pull-stream": "^3.6.9",
     "pull-stream-to-stream": "^1.3.4",
     "pump": "^3.0.0",
-    "readable-stream": "^3.0.3",
+    "readable-stream": "^3.0.6",
     "stream-to-pull-stream": "^1.7.2",
-    "through2": "^2.0.3",
     "varint": "^5.0.0"
   },
   "contributors": [

--- a/src/internals/channel.js
+++ b/src/internals/channel.js
@@ -82,6 +82,21 @@ class Channel extends stream.Duplex {
     })
   }
 
+  /**
+   * Conditionally emit errors if we have listeners. All other
+   * events are sent to EventEmitter.emit
+   * @param {string} eventName
+   * @param  {...any} args
+   * @returns {void}
+   */
+  emit (eventName, ...args) {
+    if (eventName === 'error' && !this._events.error) {
+      this.log('error', ...args)
+    } else {
+      super.emit(eventName, ...args)
+    }
+  }
+
   _destroy (err/* : Error */, callback) {
     const local = this.local
     this.log('_destroy:' + (local ? 'local' : 'remote'))

--- a/src/internals/channel.js
+++ b/src/internals/channel.js
@@ -98,10 +98,9 @@ class Channel extends stream.Duplex {
   }
 
   _destroy (err/* : Error */, callback) {
-    const local = this.local
-    this.log('_destroy:' + (local ? 'local' : 'remote'))
+    this.log('_destroy:' + (this.local ? 'local' : 'remote'))
 
-    if (local && this._opened) {
+    if (this.local && this._opened) {
       if (this._lazy && this.initiator) {
         this._open()
       }

--- a/src/internals/channel.js
+++ b/src/internals/channel.js
@@ -28,6 +28,7 @@ class Channel extends stream.Duplex {
     this.halfOpen = halfOpen
     this.destroyed = false
     this.finalized = false
+    this.local = true
 
     this._multiplex = plex
     this._dataHeader = 0
@@ -81,18 +82,9 @@ class Channel extends stream.Duplex {
     })
   }
 
-  destroy (err/* : Error */) {
-    this._destroy(err, true)
-  }
-
-  _destroy (err/* : Error */, local/* : bool */) {
+  _destroy (err/* : Error */, callback) {
+    const local = this.local
     this.log('_destroy:' + (local ? 'local' : 'remote'))
-    if (this.destroyed) {
-      this.log('already destroyed')
-      return
-    }
-
-    this.destroyed = true
 
     const hasErrorListeners = this.listenerCount('error') > 0
 
@@ -117,6 +109,7 @@ class Channel extends stream.Duplex {
     }
 
     this._finalize()
+    callback()
   }
 
   _finalize () {

--- a/src/internals/channel.js
+++ b/src/internals/channel.js
@@ -86,14 +86,6 @@ class Channel extends stream.Duplex {
     const local = this.local
     this.log('_destroy:' + (local ? 'local' : 'remote'))
 
-    const hasErrorListeners = this.listenerCount('error') > 0
-
-    if (err && (!local || hasErrorListeners)) {
-      this.emit('error', err)
-    }
-
-    this.emit('close')
-
     if (local && this._opened) {
       if (this._lazy && this.initiator) {
         this._open()
@@ -105,11 +97,11 @@ class Channel extends stream.Duplex {
           this.channel << 3 | (this.initiator ? 6 : 5),
           msg
         )
-      } catch (e) {}
+      } catch (e) { /* do nothing */ }
     }
 
     this._finalize()
-    callback()
+    callback(err)
   }
 
   _finalize () {

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -464,16 +464,10 @@ class Multiplex extends stream.Duplex {
     this._clear()
   }
 
-  destroy (err/* :: ?: Error */) {
+  _destroy (err/* :: ?: Error */, callback) {
     this.log('destroy')
-    if (this.destroyed) {
-      this.log('already destroyed')
-      return
-    }
 
-    var list = this._local.concat(this._remote)
-
-    this.destroyed = true
+    const list = this._local.concat(this._remote)
 
     if (err) {
       this.emit('error', err)
@@ -482,11 +476,12 @@ class Multiplex extends stream.Duplex {
 
     list.forEach(function (stream) {
       if (stream) {
-        stream.emit('error', err || new Error('underlying socket has been closed'))
+        stream.destroy(err)
       }
     })
 
     this._clear()
+    callback()
   }
 }
 

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -322,7 +322,7 @@ class Multiplex extends stream.Duplex {
           stream._awaitDrain++
         }
         break
-      default: {}
+      default: // no action
     }
   }
 
@@ -469,19 +469,14 @@ class Multiplex extends stream.Duplex {
 
     const list = this._local.concat(this._remote)
 
-    if (err) {
-      this.emit('error', err)
-    }
-    this.emit('close')
-
     list.forEach(function (stream) {
       if (stream) {
-        stream.destroy(err)
+        stream.destroy(err || new Error('underlying socket has been closed'))
       }
     })
 
     this._clear()
-    callback()
+    callback(err)
   }
 }
 

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -471,7 +471,7 @@ class Multiplex extends stream.Duplex {
 
     list.forEach(function (stream) {
       if (stream) {
-        stream.destroy(err || new Error('underlying socket has been closed'))
+        stream.destroy(err || new Error('Channel destroyed'))
       }
     })
 

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -304,7 +304,8 @@ class Multiplex extends stream.Duplex {
       case 5: // local error
       case 6: { // remote error
         const error = new Error(data.toString() || 'Channel destroyed')
-        stream._destroy(error, false)
+        stream.local = false
+        stream.destroy(error)
         return
       }
 
@@ -451,7 +452,8 @@ class Multiplex extends stream.Duplex {
 
     list.forEach(function (stream) {
       if (stream) {
-        stream._destroy(null, false)
+        stream.local = false
+        stream.destroy(null)
       }
     })
 

--- a/src/muxer.js
+++ b/src/muxer.js
@@ -37,7 +37,9 @@ class MultiplexMuxer extends EventEmitter {
     this.multicodec = MULTIPLEX_CODEC
 
     multiplex.on('close', () => this.emit('close'))
-    multiplex.on('error', (err) => this.emit('error', err))
+    multiplex.on('error', (err) => {
+      this.emit('error', err)
+    })
 
     multiplex.on('stream', (stream, id) => {
       const muxedConn = new Connection(

--- a/src/muxer.js
+++ b/src/muxer.js
@@ -68,9 +68,20 @@ class MultiplexMuxer extends EventEmitter {
     return conn
   }
 
-  end (callback) {
+  /**
+   * Destroys multiplex and ends all internal streams
+   *
+   * @param {Error} err Optional error to pass to end the muxer with
+   * @param {function()} callback Optional
+   * @returns {void}
+   */
+  end (err, callback) {
+    if (typeof err === 'function') {
+      callback = err
+      err = null
+    }
     callback = callback || noop
-    this.multiplex.destroy()
+    this.multiplex.destroy(err)
     callback()
   }
 }

--- a/test/internals.node.js
+++ b/test/internals.node.js
@@ -2,9 +2,9 @@
 'use strict'
 
 const chai = require('chai')
-const dirtyChai = require('dirty-chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
 const expect = chai.expect
-chai.use(dirtyChai)
 
 const concat = require('concat-stream')
 const through = require('through2')
@@ -127,15 +127,18 @@ describe('Internals - MplexCore', () => {
     const plex1 = new MplexCore()
     const stream1 = plex1.createStream()
 
+    expect(2).check(done)
+
     const plex2 = new MplexCore(function onStream (stream, id) {
       stream.on('error', function (err) {
-        expect(err.message).to.equal('0 had an error')
-        done()
+        expect(err.message).to.equal('0 had an error').mark()
       })
     })
 
     plex1.pipe(plex2)
-
+    stream1.on('error', function (err) {
+      expect(err.message).to.equal('0 had an error').mark()
+    })
     stream1.write(Buffer.from('hello'))
     stream1.destroy(new Error('0 had an error'))
   })

--- a/test/muxer.spec.js
+++ b/test/muxer.spec.js
@@ -44,6 +44,14 @@ describe('multiplex-muxer', () => {
     muxer.end(error)
   })
 
+  it('destroying with error does not throw with no listener', () => {
+    const p = pair()
+    const multiplex = new Multiplex()
+    const muxer = new Muxer(p, multiplex)
+    const error = new Error('bad things')
+    expect(() => muxer.end(error)).to.not.throw()
+  })
+
   it('can get destroyed', (done) => {
     expect(multiplex.destroyed).to.eql(false)
 

--- a/test/muxer.spec.js
+++ b/test/muxer.spec.js
@@ -32,6 +32,18 @@ describe('multiplex-muxer', () => {
     })
   })
 
+  it('can be destroyed with an error', (done) => {
+    const p = pair()
+    const multiplex = new Multiplex()
+    const muxer = new Muxer(p, multiplex)
+    const error = new Error('bad things')
+    muxer.once('error', (err) => {
+      expect(err).to.eql(error)
+      done()
+    })
+    muxer.end(error)
+  })
+
   it('can get destroyed', (done) => {
     expect(multiplex.destroyed).to.eql(false)
 


### PR DESCRIPTION
* Update dependencies
* Don't override stream.destroy as it's against the Stream api
* Override emit to only throw errors if we have listeners. This replicates some logic that was removed when fixing the stream.destroy override.
* Fix lint warnings