### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ js-libp2p-mplex
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 [![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-mplex.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-mplex)
 [![](https://img.shields.io/travis/libp2p/js-libp2p-mplex.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-mplex)
 [![Dependency Status](https://david-dm.org/libp2p/js-libp2p-mplex.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-mplex)

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-mplex#readme",
   "devDependencies": {
-    "aegir": "^18.1.0",
+    "aegir": "^18.2.1",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "dirty-chai": "^2.0.1",
     "interface-stream-muxer": "~0.6.0",
     "libp2p-tcp": "~0.13.0",
     "libp2p-websockets": "~0.12.2",
-    "multiaddr": "^6.0.4",
+    "multiaddr": "^6.0.6",
     "pull-pair": "^1.1.0",
     "through2": "^2.0.3"
   },
@@ -46,14 +46,14 @@
     "async": "^2.6.2",
     "chunky": "0.0.0",
     "concat-stream": "^1.6.2",
-    "debug": "^4.1.0",
+    "debug": "^4.1.1",
     "interface-connection": "~0.3.3",
     "pull-catch": "^1.0.1",
     "pull-stream": "^3.6.9",
     "pull-stream-to-stream": "^1.3.4",
     "pump": "^3.0.0",
     "readable-stream": "^3.1.1",
-    "stream-to-pull-stream": "^1.7.2",
+    "stream-to-pull-stream": "^1.7.3",
     "varint": "^5.0.0"
   },
   "contributors": [


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated