### PR TITLE
perf: small bl

### DIFF
--- a/src/coder/decode.js
+++ b/src/coder/decode.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const varint = require('varint')
-const { BufferList } = require('bl')
+const BufferList = require('bl/BufferList')
 
 // Decode a chunk and yield an _array_ of decoded messages
 module.exports = source => (async function * decode () {

--- a/src/coder/encode.js
+++ b/src/coder/encode.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const varint = require('varint')
-const { BufferList } = require('bl')
+const BufferList = require('bl/BufferList')
 
 const POOL_SIZE = 10 * 1024
 


### PR DESCRIPTION
This imports the `BufferList` class that does not extend duplex stream. This gets us one step closer to removing readable-stream from the bundle.