### PR TITLE
Remove the stream from internal registry upon closing

### DIFF
--- a/src/mplex.js
+++ b/src/mplex.js
@@ -97,6 +97,11 @@ class Mplex {
     return this._newStream({ id, name, type: 'receiver', registry })
   }
 
+  _removeStream (id) {
+    this._streams.initiators.delete(id)
+    this._streams.receivers.delete(id)
+  }
+
   /**
    * Creates a new stream
    * @private
@@ -121,6 +126,7 @@ class Mplex {
     const onEnd = () => {
       log('%s stream %s %s ended', type, id, name)
       registry.delete(id)
+      this._removeStream(id)
       this.onStreamEnd && this.onStreamEnd(stream)
     }
     const stream = createStream({ id, name, send, type, onEnd, maxMsgSize: this._options.maxMsgSize })
@@ -215,6 +221,7 @@ class Mplex {
       case MessageTypes.CLOSE_INITIATOR:
       case MessageTypes.CLOSE_RECEIVER:
         stream.close()
+        this._removeStream(id)
         break
       case MessageTypes.RESET_INITIATOR:
       case MessageTypes.RESET_RECEIVER:


### PR DESCRIPTION
Hi there 👋 

This PR adds logic to remove a stream from the internal registry upon closing the stream.

As it stands now, `this._streams` grows unbounded upon multiple `libp2p.dialProtocol(...)` calls. That is, it keeps growing and keeps the old streams in `this._streams`.

I'm not sure if this is the right fix, nor even the right place for it given the general connection/stream/libp2p state handling, but doing this solves the problem in my project. I'd be happy to revise and work on a more correct solution.