### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = {
+  webpack: {
+    node: {
+      // needed by random-bytes
+      crypto: true,
+
+      // needed by cipher-base
+      stream: true,
+
+      // needed by core-util-is
+      Buffer: true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,20 +39,18 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-mplex#readme",
   "devDependencies": {
-    "aegir": "^22.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
+    "aegir": "^25.0.0",
     "interface-stream-muxer": "^0.8.0",
     "p-defer": "^3.0.0",
     "random-bytes": "^1.0.0",
     "random-int": "^2.0.0",
-    "streaming-iterables": "^4.1.0"
+    "streaming-iterables": "^5.0.2",
+    "uint8arrays": "^1.1.0"
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
     "bl": "^4.0.0",
-    "buffer": "^5.5.0",
     "debug": "^4.1.1",
     "it-pipe": "^1.0.1",
     "it-pushable": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "dist",
     "src"
   ],
+  "browser": {
+    "./src/coder/encode.js": "./src/coder/encode.browser.js"
+  },
   "scripts": {
     "lint": "aegir lint",
     "build": "aegir build",

--- a/src/coder/decode.js
+++ b/src/coder/decode.js
@@ -23,7 +23,7 @@ class Decoder {
   }
 
   /**
-   * @param {Buffer|BufferList} chunk
+   * @param {Uint8Array|BufferList} chunk
    * @returns {object[]} An array of message objects
    */
   write (chunk) {
@@ -58,7 +58,7 @@ class Decoder {
   /**
    * Attempts to decode the message header from the buffer
    * @private
-   * @param {Buffer} data
+   * @param {Uint8Array} data
    * @returns {*} message header (id, type, offset, length)
    */
   _decodeHeader (data) {

--- a/src/coder/encode.browser.js
+++ b/src/coder/encode.browser.js
@@ -7,14 +7,14 @@ const POOL_SIZE = 10 * 1024
 
 class Encoder {
   constructor () {
-    this._pool = Buffer.allocUnsafe(POOL_SIZE)
+    this._pool = new Uint8Array(POOL_SIZE)
     this._poolOffset = 0
   }
 
   /**
    * Encodes the given message and returns it and its header
    * @param {*} msg The message object to encode
-   * @returns {Buffer|Buffer[]}
+   * @returns {Uint8Array|Uint8Array[]}
    */
   write (msg) {
     const pool = this._pool
@@ -25,10 +25,10 @@ class Encoder {
     varint.encode(msg.data ? msg.data.length : 0, pool, offset)
     offset += varint.encode.bytes
 
-    const header = pool.slice(this._poolOffset, offset)
+    const header = pool.subarray(this._poolOffset, offset)
 
     if (POOL_SIZE - offset < 100) {
-      this._pool = Buffer.allocUnsafe(POOL_SIZE)
+      this._pool = new Uint8Array(POOL_SIZE)
       this._poolOffset = 0
     } else {
       this._poolOffset = offset

--- a/src/coder/encode.js
+++ b/src/coder/encode.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const varint = require('varint')
 const BufferList = require('bl/BufferList')
 
@@ -8,14 +7,14 @@ const POOL_SIZE = 10 * 1024
 
 class Encoder {
   constructor () {
-    this._pool = Buffer.allocUnsafe(POOL_SIZE)
+    this._pool = new Uint8Array(POOL_SIZE)
     this._poolOffset = 0
   }
 
   /**
    * Encodes the given message and returns it and its header
    * @param {*} msg The message object to encode
-   * @returns {Buffer|Buffer[]}
+   * @returns {Uint8Array|Uint8Array[]}
    */
   write (msg) {
     const pool = this._pool
@@ -29,7 +28,7 @@ class Encoder {
     const header = pool.slice(this._poolOffset, offset)
 
     if (POOL_SIZE - offset < 100) {
-      this._pool = Buffer.allocUnsafe(POOL_SIZE)
+      this._pool = new Uint8Array(POOL_SIZE)
       this._poolOffset = 0
     } else {
       this._poolOffset = offset

--- a/src/mplex.js
+++ b/src/mplex.js
@@ -188,7 +188,7 @@ class Mplex {
    * @param {object} options
    * @param {number} options.id
    * @param {string} options.type
-   * @param {Buffer|BufferList} options.data
+   * @param {Uint8Array|BufferList} options.data
    * @returns {void}
    */
   _handleIncoming ({ id, type, data }) {

--- a/test/restrict-size.spec.js
+++ b/test/restrict-size.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const { expect } = chai
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const pipe = require('it-pipe')
 const randomBytes = require('random-bytes')
 const { tap, consume, collect } = require('streaming-iterables')

--- a/test/stream.spec.js
+++ b/test/stream.spec.js
@@ -1,16 +1,15 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const { expect } = chai
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const pipe = require('it-pipe')
 const randomBytes = require('random-bytes')
 const randomInt = require('random-int')
 const { tap, take, collect, consume, map } = require('streaming-iterables')
 const defer = require('p-defer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayConcat = require('uint8arrays/concat')
 
 const createStream = require('../src/stream')
 const { MessageTypes, MessageTypeNames } = require('../src/message-types')
@@ -31,13 +30,13 @@ const infiniteRandom = {
   }
 }
 
-const msgToBuffer = msg => Buffer.from(JSON.stringify(msg))
+const msgToBuffer = msg => uint8ArrayFromString(JSON.stringify(msg))
 
 const bufferToMessage = buf => {
-  const msg = JSON.parse(buf)
+  const msg = JSON.parse(uint8ArrayToString(buf))
   // JSON.stringify(Buffer) encodes as {"type":"Buffer","data":[1,2,3]}
   if (msg.data && msg.data.type === 'Buffer') {
-    msg.data = Buffer.from(msg.data.data)
+    msg.data = new Uint8Array(msg.data.data)
   }
   return msg
 }
@@ -565,6 +564,6 @@ describe('stream', () => {
     expect(dataMessages[0].data.length).to.equal(maxMsgSize)
     expect(dataMessages[1].data.length).to.equal(maxMsgSize)
     expect(dataMessages[2].data.length).to.equal(2)
-    expect(Buffer.concat(dataMessages.map(m => m.data.slice()))).to.deep.equal(bigMessage)
+    expect(uint8ArrayConcat(dataMessages.map(m => m.data.slice()))).to.deep.equal(bigMessage)
   })
 })


### PR DESCRIPTION
Buffer lists are still used internally but any Buffers created by this module are now Uint8Arrays.

BREAKING CHANGE:

- All use of node Buffers has been replaced with Uint8Arrays