### PR TITLE
feat: close read and write

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,17 @@ In addition to `sink` and `source` properties, this stream also has the followin
 
 #### `stream.close()`
 
-Closes the stream for **reading**. If iterating over the source of this stream in a `for await of` loop, it will return (exit the loop) after any buffered data has been consumed.
+Closes the stream for **reading** and **writing**. If iterating over the source of this stream in a `for await of` loop, it will return (exit the loop) after any buffered data has been consumed.
+
+#### `stream.closeRead()`
+
+Closes the stream for **reading**, but still allows writing. This should not typically be called by application code, but may be used for one way, push only streams.
 
 This function is called automatically by the muxer when it receives a `CLOSE` message from the remote.
 
-The source will return normally, the sink will continue to consume.
+#### `stream.closeWrite()`
+
+Closes the stream for **writing**, but still allows reading. This is useful for when you only ever wish to read from a stream.
 
 #### `stream.abort([err])`
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "aegir": "^33.1.0",
     "cborg": "^1.2.1",
     "iso-random-stream": "^2.0.0",
-    "libp2p-interfaces": "^0.10.0",
+    "libp2p-interfaces": "github:libp2p/js-libp2p-interfaces#feat/streams",
     "p-defer": "^3.0.0",
     "random-int": "^2.0.0",
     "streaming-iterables": "^5.0.4",

--- a/src/mplex.js
+++ b/src/mplex.js
@@ -216,14 +216,17 @@ class Mplex {
     switch (type) {
       case MessageTypes.MESSAGE_INITIATOR:
       case MessageTypes.MESSAGE_RECEIVER:
+        // We got data from the remote, push it into our local stream
         stream.source.push(data)
         break
       case MessageTypes.CLOSE_INITIATOR:
       case MessageTypes.CLOSE_RECEIVER:
-        stream.close()
+        // We should expect no more data from the remote, stop reading
+        stream.closeRead()
         break
       case MessageTypes.RESET_INITIATOR:
       case MessageTypes.RESET_RECEIVER:
+        // Stop reading and writing to the stream immediately
         stream.reset()
         break
       default:

--- a/src/mplex.js
+++ b/src/mplex.js
@@ -4,6 +4,7 @@ const pipe = require('it-pipe')
 const pushable = require('it-pushable')
 const log = require('debug')('libp2p:mplex')
 const abortable = require('abortable-iterator')
+const errCode = require('err-code')
 const Coder = require('./coder')
 const restrictSize = require('./restrict-size')
 const { MessageTypes, MessageTypeNames } = require('./message-types')
@@ -117,6 +118,9 @@ class Mplex {
     }
     log('new %s stream %s %s', type, id, name)
     const send = msg => {
+      if (!registry.has(id)) {
+        throw errCode(new Error('the stream is not in the muxer registry, it may have already been closed'), 'ERR_STREAM_DOESNT_EXIST')
+      }
       if (log.enabled) {
         log('%s stream %s %s send', type, id, name, { ...msg, type: MessageTypeNames[msg.type], data: msg.data && msg.data.slice() })
       }

--- a/src/stream.js
+++ b/src/stream.js
@@ -56,9 +56,16 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
     }
   }
 
-  const stream = {
+  const stream = {    
+    // Close for both Reading and Writing
+    close: () => Promise.all([
+      stream.closeRead(),
+      stream.closeWrite()
+    ]),
     // Close for reading
-    close: () => stream.source.end(),
+    closeRead: () => stream.source.end(),
+    // Close for writing
+    closeWrite: () => stream.sink([]),
     // Close for reading and writing (local error)
     abort: err => {
       log('%s stream %s abort', type, name, err)

--- a/src/stream.js
+++ b/src/stream.js
@@ -56,7 +56,7 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
     }
   }
 
-  const stream = {    
+  const stream = {
     // Close for both Reading and Writing
     close: () => Promise.all([
       stream.closeRead(),

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -2,7 +2,6 @@
 'use strict'
 
 const tests = require('libp2p-interfaces/src/stream-muxer/tests')
-
 const Mplex = require('../src')
 
 describe('compliance', () => {

--- a/test/stream.spec.js
+++ b/test/stream.spec.js
@@ -230,9 +230,9 @@ describe('stream', () => {
     pipe(
       receiver,
       map(msg => {
-        // when the initiator sends a CLOSE message, we call close
+        // when the initiator sends a CLOSE message, we close for reading
         if (msg.type === MessageTypes.CLOSE_INITIATOR) {
-          receiver.close()
+          receiver.closeRead()
         }
         return msgToBuffer(msg)
       }),


### PR DESCRIPTION
This also now throws an error when a write is attempted on a non existent stream. Previously we would just send the message, but this is against the mplex protocol.

This is technically a **breaking change** due to how `stream.close` was only closing the read end of the stream, which is incorrect behavior.

TODO:
- [ ] Ensure `onEnd` triggers for closed streams that haven't been written to yet. 

- [ ] requires https://github.com/libp2p/js-libp2p-interfaces/pull/67