### PR TITLE
fix: stream close

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-mplex#readme",
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^28.0.0",
     "interface-stream-muxer": "^0.8.0",
     "p-defer": "^3.0.0",
     "random-bytes": "^1.0.0",
@@ -55,6 +55,7 @@
     "abortable-iterator": "^3.0.0",
     "bl": "^4.0.0",
     "debug": "^4.1.1",
+    "err-code": "^2.0.3",
     "it-pipe": "^1.0.1",
     "it-pushable": "^1.3.1",
     "varint": "^5.0.0"

--- a/src/coder/decode.js
+++ b/src/coder/decode.js
@@ -57,6 +57,7 @@ class Decoder {
 
   /**
    * Attempts to decode the message header from the buffer
+   *
    * @private
    * @param {Uint8Array} data
    * @returns {*} message header (id, type, offset, length)

--- a/src/coder/encode.browser.js
+++ b/src/coder/encode.browser.js
@@ -13,7 +13,8 @@ class Encoder {
 
   /**
    * Encodes the given message and returns it and its header
-   * @param {*} msg The message object to encode
+   *
+   * @param {*} msg - The message object to encode
    * @returns {Uint8Array|Uint8Array[]}
    */
   write (msg) {

--- a/src/coder/encode.js
+++ b/src/coder/encode.js
@@ -13,7 +13,8 @@ class Encoder {
 
   /**
    * Encodes the given message and returns it and its header
-   * @param {*} msg The message object to encode
+   *
+   * @param {*} msg - The message object to encode
    * @returns {Buffer|Buffer[]}
    */
   write (msg) {

--- a/src/mplex.js
+++ b/src/mplex.js
@@ -11,11 +11,11 @@ const createStream = require('./stream')
 
 class Mplex {
   /**
-   * @constructor
+   * @class
    * @param {object} options
-   * @param {function(*)} options.onStream Called whenever an inbound stream is created
-   * @param {function(*)} options.onStreamEnd Called whenever a stream ends
-   * @param {AbortSignal} options.signal An AbortController signal
+   * @param {function(*)} options.onStream - Called whenever an inbound stream is created
+   * @param {function(*)} options.onStreamEnd - Called whenever a stream ends
+   * @param {AbortSignal} options.signal - An AbortController signal
    */
   constructor (options) {
     options = options || {}
@@ -45,18 +45,19 @@ class Mplex {
     this.source = this._createSource()
 
     /**
-     * @property {function} onStream
+     * @property {Function} onStream
      */
     this.onStream = options.onStream
 
     /**
-     * @property {function} onStreamEnd
+     * @property {Function} onStreamEnd
      */
     this.onStreamEnd = options.onStreamEnd
   }
 
   /**
    * Returns a Map of streams and their ids
+   *
    * @returns {Map<number,*>}
    */
   get streams () {
@@ -74,7 +75,8 @@ class Mplex {
   /**
    * Initiate a new stream with the given name. If no name is
    * provided, the id of th stream will be used.
-   * @param {string} [name] If name is not a string it will be cast to one
+   *
+   * @param {string} [name] - If name is not a string it will be cast to one
    * @returns {Stream}
    */
   newStream (name) {
@@ -86,6 +88,7 @@ class Mplex {
 
   /**
    * Called whenever an inbound stream is created
+   *
    * @private
    * @param {*} options
    * @param {number} options.id
@@ -99,12 +102,13 @@ class Mplex {
 
   /**
    * Creates a new stream
+   *
    * @private
    * @param {object} options
    * @param {number} options.id
    * @param {string} options.name
    * @param {string} options.type
-   * @param {Map<number, *>} options.registry A map of streams to their ids
+   * @param {Map<number, *>} options.registry - A map of streams to their ids
    * @returns {*} A muxed stream
    */
   _newStream ({ id, name, type, registry }) {
@@ -131,6 +135,7 @@ class Mplex {
   /**
    * Creates a sink with an abortable source. Incoming messages will
    * also have their size restricted. All messages will be varint decoded.
+   *
    * @private
    * @returns {*} Returns an iterable sink
    */
@@ -165,6 +170,7 @@ class Mplex {
   /**
    * Creates a source that restricts outgoing message sizes
    * and varint encodes them.
+   *
    * @private
    * @returns {*} An iterable source
    */

--- a/src/restrict-size.js
+++ b/src/restrict-size.js
@@ -5,7 +5,8 @@ const MAX_MSG_SIZE = 1 << 20 // 1MB
 /**
  * Creates an iterable transform that restricts message sizes to
  * the given maximum size.
- * @param {number} [max] The maximum message size. Defaults to 1MB
+ *
+ * @param {number} [max] - The maximum message size. Defaults to 1MB
  * @returns {*} An iterable transform.
  */
 module.exports = max => {

--- a/src/stream.js
+++ b/src/stream.js
@@ -64,7 +64,7 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
       log('%s stream %s abort', type, name, err)
       // End the source with the passed error
       stream.source.end(err)
-      abortController.abort(err)
+      abortController.abort()
       onSinkEnd(err)
     },
     // Close immediately for reading and writing (remote error)

--- a/test/stream.spec.js
+++ b/test/stream.spec.js
@@ -77,11 +77,13 @@ describe('stream', () => {
     const id = randomInt(1000)
     const name = `STREAM${Date.now()}`
     const deferred = defer()
-    const stream = createStream({ id, name, onEnd: () => deferred.resolve(), send: mockSend })
+    const stream = createStream({ id, name, onEnd: deferred.resolve, send: mockSend })
 
-    stream.abort()
+    const error = new Error('boom')
+    stream.abort(error)
 
-    await deferred.promise
+    const err = await deferred.promise
+    expect(err).to.equal(error)
   })
 
   it('should end a stream when it is reset', async () => {
@@ -90,11 +92,13 @@ describe('stream', () => {
     const id = randomInt(1000)
     const name = `STREAM${Date.now()}`
     const deferred = defer()
-    const stream = createStream({ id, name, onEnd: () => deferred.resolve(), send: mockSend })
+    const stream = createStream({ id, name, onEnd: deferred.resolve, send: mockSend })
 
     stream.reset()
 
-    await deferred.promise
+    const err = await deferred.promise
+    expect(err).to.exist()
+    expect(err).to.have.property('code', 'ERR_MPLEX_STREAM_RESET')
   })
 
   it('should send data with MESSAGE_INITIATOR messages if stream initiator', async () => {

--- a/test/stream.spec.js
+++ b/test/stream.spec.js
@@ -71,6 +71,32 @@ describe('stream', () => {
     expect(msgs[0].data).to.deep.equal(name)
   })
 
+  it('should end a stream when it is aborted', async () => {
+    const msgs = []
+    const mockSend = msg => msgs.push(msg)
+    const id = randomInt(1000)
+    const name = `STREAM${Date.now()}`
+    const deferred = defer()
+    const stream = createStream({ id, name, onEnd: () => deferred.resolve(), send: mockSend })
+
+    stream.abort()
+
+    await deferred.promise
+  })
+
+  it('should end a stream when it is reset', async () => {
+    const msgs = []
+    const mockSend = msg => msgs.push(msg)
+    const id = randomInt(1000)
+    const name = `STREAM${Date.now()}`
+    const deferred = defer()
+    const stream = createStream({ id, name, onEnd: () => deferred.resolve(), send: mockSend })
+
+    stream.reset()
+
+    await deferred.promise
+  })
+
   it('should send data with MESSAGE_INITIATOR messages if stream initiator', async () => {
     const msgs = []
     const mockSend = msg => msgs.push(msg)


### PR DESCRIPTION
This adds some more aggressive closures to streams on abort and reset. It was previously possible for unwritten streams to not properly end when aborted/reset, which would result in them not properly notifying libp2p/application code of the termination. This could also result in streams lingering.

* This also includes some formatting updates needed due to the Aegir bump

I'd like to do some more clean up here but am reserving that for https://github.com/libp2p/js-libp2p-mplex/pull/115, which will create some breaking behavior.

This should also resolve part of https://github.com/libp2p/js-libp2p-mplex/pull/113.