### PR TITLE
feat: close read and write streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,17 @@ In addition to `sink` and `source` properties, this stream also has the followin
 
 #### `stream.close()`
 
-Closes the stream for **reading**. If iterating over the source of this stream in a `for await of` loop, it will return (exit the loop) after any buffered data has been consumed.
+Closes the stream for **reading** and **writing**. If iterating over the source of this stream in a `for await of` loop, it will return (exit the loop) after any buffered data has been consumed.
+
+#### `stream.closeRead()`
+
+Closes the stream for **reading**, but still allows writing. This should not typically be called by application code, but may be used for one way, push only streams.
 
 This function is called automatically by the muxer when it receives a `CLOSE` message from the remote.
 
-The source will return normally, the sink will continue to consume.
+#### `stream.closeWrite()`
+
+Closes the stream for **writing**, but still allows reading. This is useful for when you only ever wish to read from a stream.
 
 #### `stream.abort([err])`
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "aegir": "^33.1.0",
     "cborg": "^1.2.1",
     "iso-random-stream": "^2.0.0",
-    "libp2p-interfaces": "^0.10.0",
+    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#feat/muxed-stream-close-read-and-write",
     "p-defer": "^3.0.0",
     "random-int": "^2.0.0",
     "streaming-iterables": "^5.0.4",

--- a/test/stream.spec.js
+++ b/test/stream.spec.js
@@ -232,7 +232,7 @@ describe('stream', () => {
       map(msg => {
         // when the initiator sends a CLOSE message, we call close
         if (msg.type === MessageTypes.CLOSE_INITIATOR) {
-          receiver.close()
+          receiver.closeRead()
         }
         return msgToBuffer(msg)
       }),


### PR DESCRIPTION
__ Created new PR with changes from #115 on top of current master branch __

This also now throws an error when a write is attempted on a non existent stream. Previously we would just send the message, but this is against the mplex protocol.

This is technically a **breaking change** due to how `stream.close` was only closing the read end of the stream, which is incorrect behavior.

Needs:
- [ ] requires https://github.com/libp2p/js-libp2p-interfaces/pull/90

Related to #120 

Closes #115 