### PR TITLE
feat: close read and write streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,17 @@ In addition to `sink` and `source` properties, this stream also has the followin
 
 #### `stream.close()`
 
-Closes the stream for **reading**. If iterating over the source of this stream in a `for await of` loop, it will return (exit the loop) after any buffered data has been consumed.
+Closes the stream for **reading** and **writing**. If iterating over the source of this stream in a `for await of` loop, it will return (exit the loop) after any buffered data has been consumed.
+
+#### `stream.closeRead()`
+
+Closes the stream for **reading**, but still allows writing. This should not typically be called by application code, but may be used for one way, push only streams.
 
 This function is called automatically by the muxer when it receives a `CLOSE` message from the remote.
 
-The source will return normally, the sink will continue to consume.
+#### `stream.closeWrite()`
+
+Closes the stream for **writing**, but still allows reading. This is useful for when you only ever wish to read from a stream.
 
 #### `stream.abort([err])`
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "aegir": "^33.1.0",
     "cborg": "^1.2.1",
     "iso-random-stream": "^2.0.0",
-    "libp2p-interfaces": "^0.10.0",
+    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#feat/muxed-stream-close-read-and-write",
     "p-defer": "^3.0.0",
     "random-int": "^2.0.0",
     "streaming-iterables": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "aegir": "^33.1.0",
     "cborg": "^1.2.1",
     "iso-random-stream": "^2.0.0",
-    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#feat/muxed-stream-close-read-and-write",
+    "libp2p-interfaces": "github:filoozom/js-libp2p-interfaces#close-read-write",
     "p-defer": "^3.0.0",
     "random-int": "^2.0.0",
     "streaming-iterables": "^5.0.4",

--- a/src/stream.js
+++ b/src/stream.js
@@ -112,12 +112,12 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
     // Close for reading and writing (local error)
     abort: err => {
       log('%s stream %s abort', type, name, err)
-      return closeAll(abortController, err)
+      closeAll(abortController, err)
     },
     // Close immediately for reading and writing (remote error)
     reset: () => {
       const err = errCode(new Error('stream reset'), ERR_MPLEX_STREAM_RESET)
-      return closeAll(resetController, err)
+      closeAll(resetController, err)
     },
     sink: async source => {
       if (sinkInProgress) {

--- a/src/stream.js
+++ b/src/stream.js
@@ -66,7 +66,7 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
     defers[type] = []
   }
 
-  const closeWrite = (controller, err) => {
+  const closeWrite = (controller) => {
     if (ended.sink) {
       return
     }
@@ -75,8 +75,8 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
     defers.sink.push(defer)
 
     // Make sure we're still in the sink when aborting
-    // If the sink wasn't opened yet, just close it without creating a new stream
-    sinkInProgress && !ended.sink ? controller.abort() : end('sink', err)
+    // If the sink wasn't opened yet, open it and immediately close
+    sinkInProgress ? controller.abort() : stream.sink([])
     return defer.promise
   }
 
@@ -94,7 +94,7 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
 
   const closeAll = (controller, err) => {
     return Promise.all([
-      closeWrite(controller, err),
+      closeWrite(controller),
       closeRead(err)
     ])
   }

--- a/src/stream.js
+++ b/src/stream.js
@@ -50,7 +50,6 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
     if (!ended[type]) {
       ended[type] = true
       log('%s stream %s %s end', type, name, type, err)
-      stream.timeline[`${type}Close`] = Date.now()
 
       if (ended.source && ended.sink) {
         stream.timeline.close = Date.now()

--- a/src/stream.js
+++ b/src/stream.js
@@ -110,6 +110,7 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
         throw errCode(new Error('the sink was already opened'), 'ERR_SINK_ALREADY_OPENED')
       }
 
+      sinkInProgress = true
       source = abortable(source, [
         { signal: abortController.signal, options: { abortMessage: 'stream aborted', abortCode: ERR_MPLEX_STREAM_ABORT } },
         { signal: resetController.signal, options: { abortMessage: 'stream reset', abortCode: ERR_MPLEX_STREAM_RESET } },

--- a/src/stream.js
+++ b/src/stream.js
@@ -40,8 +40,8 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
 
   let sinkInProgress = false
   let endErr
-  let ended = {}
-  let defers = {}
+  const ended = {}
+  const defers = {}
 
   const end = (type, err) => {
     if (!ended[type]) {
@@ -80,7 +80,7 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
     stream.source.end(err)
     return defers.source.promise
   }
-  
+
   const closeAll = (controller, err) => {
     return Promise.all([
       closeWrite(controller, err),

--- a/src/stream.js
+++ b/src/stream.js
@@ -60,11 +60,11 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
     sinkEnded = true
     log('%s stream %s sink end', type, name, err)
     if (err && !endErr) endErr = err
-    if (sinkClosedDefer) sinkClosedDefer.resolve()
     if (sourceEnded) {
       stream.timeline.close = Date.now()
       onEnd(endErr)
     }
+    if (sinkClosedDefer) sinkClosedDefer.resolve()
   }
 
   /** @type {MuxedStream} */

--- a/src/stream.js
+++ b/src/stream.js
@@ -11,6 +11,7 @@ const { InitiatorMessageTypes, ReceiverMessageTypes } = require('./message-types
 
 const ERR_MPLEX_STREAM_RESET = 'ERR_MPLEX_STREAM_RESET'
 const ERR_MPLEX_STREAM_ABORT = 'ERR_MPLEX_STREAM_ABORT'
+const MPLEX_WRITE_STREAM_CLOSED = 'MPLEX_WRITE_STREAM_CLOSED'
 
 /**
  * @typedef {import('libp2p-interfaces/src/stream-muxer/types').MuxedStream} MuxedStream
@@ -99,7 +100,7 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
       sinkCalled = true
       source = abortable(source, [
         { signal: abortController.signal, options: { abortMessage: 'stream aborted', abortCode: ERR_MPLEX_STREAM_ABORT } },
-        { signal: resetController.signal, options: { abortMessage: 'stream reset', abortCode: ERR_MPLEX_STREAM_RESET } },        
+        { signal: resetController.signal, options: { abortMessage: 'stream reset', abortCode: ERR_MPLEX_STREAM_RESET } },
         { signal: writeCloseController.signal, options: { abortMessage: 'write stream closed', abortCode: MPLEX_WRITE_STREAM_CLOSED } }
       ])
 

--- a/src/stream.js
+++ b/src/stream.js
@@ -102,14 +102,14 @@ module.exports = ({ id, name, send, onEnd = () => {}, type = 'initiator', maxMsg
       // End the source with the passed error
       stream.source.end(err)
       abortController.abort()
-      onSinkEnd(err)
+      sinkInProgress || onSinkEnd(err)
     },
     // Close immediately for reading and writing (remote error)
     reset: () => {
       const err = errCode(new Error('stream reset'), ERR_MPLEX_STREAM_RESET)
       resetController.abort()
       stream.source.end(err)
-      onSinkEnd(err)
+      sinkInProgress || onSinkEnd(err)
     },
     sink: async source => {
       if (sinkInProgress) {

--- a/test/stream.spec.js
+++ b/test/stream.spec.js
@@ -232,7 +232,7 @@ describe('stream', () => {
       map(msg => {
         // when the initiator sends a CLOSE message, we call close
         if (msg.type === MessageTypes.CLOSE_INITIATOR) {
-          receiver.close()
+          receiver.closeRead()
         }
         return msgToBuffer(msg)
       }),


### PR DESCRIPTION
Based on #121 and fixes and issue when the sink was already written to.

This also prohibits the sink function from being called a second time, as it would break either way.

There's still the issue that the sink does not abort without writing to it.

Adding tests.

Related to #120

Closed #121
Closes  #115

Needs:

- [ ] https://github.com/libp2p/js-libp2p-interfaces/pull/92