### PR TITLE
perf: do not call varint.decode() if buffer has 0 length

### DIFF
--- a/src/coder/decode.js
+++ b/src/coder/decode.js
@@ -33,6 +33,10 @@ class Decoder {
     const msgs = []
 
     while (true) {
+      if (!this._buffer.length) {
+        // after consuming the whole length, _buffer has 0 length so don't want to bother varint
+        break;
+      }
       if (!this._headerInfo) {
         try {
           this._headerInfo = this._decodeHeader(this._bufferProxy)

--- a/src/coder/decode.js
+++ b/src/coder/decode.js
@@ -35,7 +35,7 @@ class Decoder {
     while (true) {
       if (!this._buffer.length) {
         // after consuming the whole length, _buffer has 0 length so don't want to bother varint
-        break;
+        break
       }
       if (!this._headerInfo) {
         try {

--- a/src/coder/decode.js
+++ b/src/coder/decode.js
@@ -32,11 +32,7 @@ class Decoder {
     this._buffer.append(chunk)
     const msgs = []
 
-    while (true) {
-      if (!this._buffer.length) {
-        // after consuming the whole length, _buffer has 0 length so don't want to bother varint
-        break
-      }
+    while (this._buffer.length) {
       if (!this._headerInfo) {
         try {
           this._headerInfo = this._decodeHeader(this._bufferProxy)


### PR DESCRIPTION
**Motivation**
+ As noted in https://github.com/ChainSafe/lodestar/issues/3467, 80%-90% of the `varint.decode()` function time is used to handle `varint.decode()` RangeError because the buffer length is 0

<img width="836" alt="Screen Shot 2021-11-30 at 15 03 19" src="https://user-images.githubusercontent.com/10568965/144035251-3d39da5d-50b3-4e86-ae4e-df955d25a9b1.png">


+ after consuming the whole length, _buffer has 0 length so don't want to bother varint