### PR TITLE
fix: remove abort controller dep

### DIFF
--- a/examples/dialer.js
+++ b/examples/dialer.js
@@ -3,7 +3,6 @@
 
 const tcp = require('net')
 const pipe = require('it-pipe')
-const AbortController = require('abort-controller')
 const { toIterable } = require('./util')
 const Mplex = require('../src')
 

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "uint8arrays": "^3.0.0"
   },
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.2",
     "bl": "^5.0.0",
     "debug": "^4.3.1",

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const abortable = require('abortable-iterator')
-const AbortController = require('abort-controller')
 const log = require('debug')('libp2p:mplex:stream')
 const pushable = require('it-pushable')
 const BufferList = require('bl/BufferList')


### PR DESCRIPTION
`AbortController` and `AbortSignal` are in browsers and LTS node so the `abort-controller` and `native-abort-controller` deps aren't required any more.