### PR TITLE
feat: close read and write streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,8 +153,8 @@
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-compliance-tests": "^2.0.0",
-    "@libp2p/interfaces": "^2.0.0",
+    "@libp2p/interface-compliance-tests": "^2.0.1",
+    "@libp2p/interfaces": "^2.0.1",
     "@types/varint": "^6.0.0",
     "aegir": "^37.0.10",
     "cborg": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -153,8 +153,8 @@
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-compliance-tests": "^1.1.32",
-    "@libp2p/interfaces": "^1.3.31",
+    "@libp2p/interface-compliance-tests": "^2.0.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@types/varint": "^6.0.0",
     "aegir": "^37.0.10",
     "cborg": "^1.8.1",

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -204,18 +204,14 @@ export class MplexStreamMuxer implements StreamMuxer {
         if (err != null) {
           s.abort(err)
         } else {
-          void s.close().catch(err => {
-            log.error(err)
-          })
+          s.close()
         }
       }
       for (const s of receivers.values()) {
         if (err != null) {
           s.abort(err)
         } else {
-          void s.close().catch(err => {
-            log.error(err)
-          })
+          s.close()
         }
       }
     }
@@ -264,9 +260,7 @@ export class MplexStreamMuxer implements StreamMuxer {
       case MessageTypes.CLOSE_INITIATOR:
       case MessageTypes.CLOSE_RECEIVER:
         // We should expect no more data from the remote, stop reading
-        void stream.closeRead().catch(err => {
-          log.error(err)
-        })
+        stream.closeRead()
         break
       case MessageTypes.RESET_INITIATOR:
       case MessageTypes.RESET_RECEIVER:

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -9,6 +9,7 @@ import { createStream } from './stream.js'
 import { toString as uint8ArrayToString } from 'uint8arrays'
 import { trackedMap } from '@libp2p/tracked-map'
 import { logger } from '@libp2p/logger'
+import errCode from 'err-code'
 import type { Components } from '@libp2p/interfaces/components'
 import type { Sink } from 'it-stream-types'
 import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interfaces/stream-muxer'
@@ -130,6 +131,10 @@ export class MplexStreamMuxer implements StreamMuxer {
     }
 
     const send = (msg: Message) => {
+      if (!registry.has(id)) {
+        throw errCode(new Error('the stream is not in the muxer registry, it may have already been closed'), 'ERR_STREAM_DOESNT_EXIST')
+      }
+
       if (log.enabled) {
         log.trace('%s stream %s send', type, id, printMessage(msg))
       }
@@ -241,14 +246,17 @@ export class MplexStreamMuxer implements StreamMuxer {
     switch (type) {
       case MessageTypes.MESSAGE_INITIATOR:
       case MessageTypes.MESSAGE_RECEIVER:
+        // We got data from the remote, push it into our local stream
         stream.source.push(message.data.slice())
         break
       case MessageTypes.CLOSE_INITIATOR:
       case MessageTypes.CLOSE_RECEIVER:
-        stream.close()
+        // We should expect no more data from the remote, stop reading
+        stream.closeRead()
         break
       case MessageTypes.RESET_INITIATOR:
       case MessageTypes.RESET_RECEIVER:
+        // Stop reading and writing to the stream immediately
         stream.reset()
         break
       default:

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -201,10 +201,22 @@ export class MplexStreamMuxer implements StreamMuxer {
       const { initiators, receivers } = this._streams
       // Abort all the things!
       for (const s of initiators.values()) {
-        s.abort(err)
+        if (err != null) {
+          s.abort(err)
+        } else {
+          void s.close().catch(err => {
+            log.error(err)
+          })
+        }
       }
       for (const s of receivers.values()) {
-        s.abort(err)
+        if (err != null) {
+          s.abort(err)
+        } else {
+          void s.close().catch(err => {
+            log.error(err)
+          })
+        }
       }
     }
     const source = pushableV<Message>({ onEnd })
@@ -252,7 +264,9 @@ export class MplexStreamMuxer implements StreamMuxer {
       case MessageTypes.CLOSE_INITIATOR:
       case MessageTypes.CLOSE_RECEIVER:
         // We should expect no more data from the remote, stop reading
-        stream.closeRead()
+        void stream.closeRead().catch(err => {
+          log.error(err)
+        })
         break
       case MessageTypes.RESET_INITIATOR:
       case MessageTypes.RESET_RECEIVER:

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -32,6 +32,7 @@ export function createStream (options: Options): MplexStream {
 
   const abortController = new AbortController()
   const resetController = new AbortController()
+  const closeController = new AbortController()
   const Types = type === 'initiator' ? InitiatorMessageTypes : ReceiverMessageTypes
   const externalId = type === 'initiator' ? (`i${id}`) : `r${id}`
   const streamName = `${name == null ? id : name}`
@@ -50,7 +51,7 @@ export function createStream (options: Options): MplexStream {
     }
 
     sourceEnded = true
-    log.trace('%s stream %s source end', type, streamName, err)
+    log.trace('%s stream %s source end - err: %o', type, streamName, err)
 
     if (err != null && endErr == null) {
       endErr = err
@@ -89,35 +90,53 @@ export function createStream (options: Options): MplexStream {
   const stream = {
     // Close for both Reading and Writing
     close: async () => {
+      log.trace('%s stream %s close', type, streamName)
+
       await Promise.all([
         stream.closeRead(),
         stream.closeWrite()
       ])
     },
+
     // Close for reading
     closeRead: async () => {
+      log.trace('%s stream %s closeRead', type, streamName)
+
       if (sourceEnded) {
         return
       }
 
       await stream.source.end()
     },
+
     // Close for writing
     closeWrite: async () => {
+      log.trace('%s stream %s closeWrite', type, streamName)
+
       if (sinkEnded) {
         return
       }
 
-      await stream.sink([])
+      closeController.abort()
+
+      try {
+        send({ id, type: Types.CLOSE })
+      } catch (err) {
+        log.trace('%s stream %s error sending close', type, name, err)
+      }
+
+      onSinkEnd()
     },
+
     // Close for reading and writing (local error)
-    abort: (err?: Error) => {
+    abort: (err: Error) => {
       log.trace('%s stream %s abort', type, streamName, err)
       // End the source with the passed error
       stream.source.end(err)
       abortController.abort()
       onSinkEnd(err)
     },
+
     // Close immediately for reading and writing (remote error)
     reset: () => {
       const err = errCode(new Error('stream reset'), ERR_MPLEX_STREAM_RESET)
@@ -125,6 +144,7 @@ export function createStream (options: Options): MplexStream {
       stream.source.end(err)
       onSinkEnd(err)
     },
+
     sink: async (source: Source<Uint8Array>) => {
       if (sinkEnded) {
         throw errCode(new Error('stream closed for writing'), ERR_MPLEX_SINK_ENDED)
@@ -132,7 +152,8 @@ export function createStream (options: Options): MplexStream {
 
       source = abortableSource(source, anySignal([
         abortController.signal,
-        resetController.signal
+        resetController.signal,
+        closeController.signal
       ]))
 
       try {
@@ -159,6 +180,10 @@ export function createStream (options: Options): MplexStream {
         }
       } catch (err: any) {
         if (err.type === 'aborted' && err.message === 'The operation was aborted') {
+          if (closeController.signal.aborted) {
+            return
+          }
+
           if (resetController.signal.aborted) {
             err.message = 'stream reset'
             err.code = ERR_MPLEX_STREAM_RESET
@@ -195,10 +220,13 @@ export function createStream (options: Options): MplexStream {
 
       onSinkEnd()
     },
+
     source: pushable<Uint8Array>({
       onEnd: onSourceEnd
     }),
+
     timeline,
+
     id: externalId
   }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -87,30 +87,28 @@ export function createStream (options: Options): MplexStream {
     }
   }
 
-  const stream = {
+  const stream: MplexStream = {
     // Close for both Reading and Writing
-    close: async () => {
+    close: () => {
       log.trace('%s stream %s close', type, streamName)
 
-      await Promise.all([
-        stream.closeRead(),
-        stream.closeWrite()
-      ])
+      stream.closeRead()
+      stream.closeWrite()
     },
 
     // Close for reading
-    closeRead: async () => {
+    closeRead: () => {
       log.trace('%s stream %s closeRead', type, streamName)
 
       if (sourceEnded) {
         return
       }
 
-      await stream.source.end()
+      stream.source.end()
     },
 
     // Close for writing
-    closeWrite: async () => {
+    closeWrite: () => {
       log.trace('%s stream %s closeWrite', type, streamName)
 
       if (sinkEnded) {

--- a/test/stream.spec.ts
+++ b/test/stream.spec.ts
@@ -94,7 +94,7 @@ async function streamPair (n: number, onInitiatorMessage?: onMessage, onReceiver
 
       // when the initiator sends a CLOSE message, we call close
       if (msg.type === MessageTypes.CLOSE_INITIATOR) {
-        receiver.closeRead()
+        void receiver.closeRead()
       }
 
       // when the initiator sends a RESET message, we call close
@@ -114,7 +114,7 @@ async function streamPair (n: number, onInitiatorMessage?: onMessage, onReceiver
 
         // when the receiver sends a CLOSE message, we call close
         if (msg.type === MessageTypes.CLOSE_RECEIVER) {
-          initiator.close()
+          void initiator.close()
         }
 
         // when the receiver sends a RESET message, we call close

--- a/test/stream.spec.ts
+++ b/test/stream.spec.ts
@@ -94,7 +94,7 @@ async function streamPair (n: number, onInitiatorMessage?: onMessage, onReceiver
 
       // when the initiator sends a CLOSE message, we call close
       if (msg.type === MessageTypes.CLOSE_INITIATOR) {
-        receiver.close()
+        receiver.closeRead()
       }
 
       // when the initiator sends a RESET message, we call close


### PR DESCRIPTION
This also now throws an error when a write is attempted on a non existent stream. Previously we would just send the message, but this is against the mplex protocol.

Refs: #120
Supersedes: #115