### PR TITLE
fix: add per-connection stream limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Creates a factory that can be used to create new muxers.
 
 `options` is an optional `Object` that may have the following properties:
 
-* `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 1024 * 1024)
-*
+* `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 1 << 20)
+* `maxStreamsPerConnection` - a number that defines how many streams are allowed per connection (default: 1024)
 
 ### `const muxer = factory.createStreamMuxer(components, [options])`
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ npm install @libp2p/mplex
 import { Mplex } from '@libp2p/mplex'
 import { pipe } from 'it-pipe'
 
-const muxer = new Mplex({
+const factory = new Mplex()
+
+const muxer = factory.createStreamMuxer(components, {
   onStream: stream => { // Receive a duplex stream from the remote
     // ...receive data from the remote and optionally send data back
   },
@@ -46,7 +48,16 @@ pipe([1, 2, 3], stream)
 
 ## API
 
-### `const muxer = new Mplex([options])`
+### `const factory = new Mplex([options])`
+
+Creates a factory that can be used to create new muxers.
+
+`options` is an optional `Object` that may have the following properties:
+
+* `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 1024 * 1024)
+*
+
+### `const muxer = factory.createStreamMuxer(components, [options])`
 
 Create a new _duplex_ stream that can be piped together with a connection in order to allow multiplexed communications.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,33 @@ import type { Components } from '@libp2p/interfaces/components'
 import type { StreamMuxerFactory, StreamMuxerInit } from '@libp2p/interfaces/stream-muxer'
 import { MplexStreamMuxer } from './mplex.js'
 
-export interface MplexInit extends StreamMuxerInit {
+export interface MplexInit {
+  /**
+   * The maximum size of message that can be sent in one go in bytes.
+   * Messages larger than this will be split into multiple smaller
+   * messages.
+   */
   maxMsgSize?: number
+
+  /**
+   * The maximum number of multiplexed streams that can be open at any
+   * one time. An attempt to open more than this will throw.
+   */
+  maxStreamsPerConnection?: number
 }
 
 export class Mplex implements StreamMuxerFactory {
   public protocol = '/mplex/6.7.0'
+  private readonly init: MplexInit
 
-  createStreamMuxer (components: Components, init?: MplexInit) {
-    return new MplexStreamMuxer(components, init)
+  constructor (init: MplexInit = {}) {
+    this.init = init
+  }
+
+  createStreamMuxer (components: Components, init: StreamMuxerInit = {}) {
+    return new MplexStreamMuxer(components, {
+      ...init,
+      ...this.init
+    })
   }
 }

--- a/test/mplex.spec.ts
+++ b/test/mplex.spec.ts
@@ -1,0 +1,57 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 5] */
+
+import { expect } from 'aegir/chai'
+import { Mplex } from '../src/index.js'
+import { Components } from '@libp2p/interfaces/components'
+import type { NewStreamMessage } from '../src/message-types.js'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
+import { encode } from '../src/encode.js'
+import all from 'it-all'
+
+describe('mplex', () => {
+  it('should restrict number of initiator streams per connection', async () => {
+    const maxStreamsPerConnection = 10
+    const factory = new Mplex({
+      maxStreamsPerConnection
+    })
+    const components = new Components()
+    const muxer = factory.createStreamMuxer(components)
+
+    // max out the streams for this connection
+    for (let i = 0; i < maxStreamsPerConnection; i++) {
+      muxer.newStream()
+    }
+
+    // open one more
+    expect(() => muxer.newStream()).to.throw().with.property('code', 'ERR_TOO_MANY_STREAMS')
+  })
+
+  it('should restrict number of recipient streams per connection', async () => {
+    const maxStreamsPerConnection = 10
+    const factory = new Mplex({
+      maxStreamsPerConnection
+    })
+    const components = new Components()
+    const muxer = factory.createStreamMuxer(components)
+
+    // max out the streams for this connection
+    for (let i = 0; i < maxStreamsPerConnection; i++) {
+      muxer.newStream()
+    }
+
+    // simulate a new incoming stream
+    const source: NewStreamMessage[] = [{
+      id: 17,
+      type: 0,
+      data: uint8ArrayFromString('17')
+    }]
+
+    const data = uint8ArrayConcat(await all(encode(source)))
+
+    await muxer.sink([data])
+
+    await expect(all(muxer.source)).to.eventually.be.rejected.with.property('code', 'ERR_TOO_MANY_STREAMS')
+  })
+})


### PR DESCRIPTION
Limits the total number of streams that can be opened to 1024 per connection.

This can be overridden by passing an option to the constructor.