### PR TITLE
export mplex stream muxer class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import type { Components } from '@libp2p/interfaces/components'
 import type { StreamMuxerFactory, StreamMuxerInit } from '@libp2p/interfaces/stream-muxer'
 import { MplexStreamMuxer } from './mplex.js'
 
+// Export MplexStreamMuxer in case library users wish to use it directly.
+export { MplexStreamMuxer } from './mplex.js';
+
 export interface MplexInit {
   /**
    * The maximum size of message that can be sent in one go in bytes.


### PR DESCRIPTION
Export the MplexStreamMuxer so it can also be constructed directly without using
a factory, if desired by the downstream users.

For example:

```ts
import { MplexStreamMuxer } from '@libp2p/mplex'

  // muxer is the mplex stream muxer.
  private muxer: MplexStreamMuxer

    this.muxer = new MplexStreamMuxer(new Components(), {
      onIncomingStream: this.handleIncomingStream.bind(this),
      onStreamEnd: this.handleStreamEnd.bind(this),
    })
```