### PR TITLE
fix!: limit incoming and outgoing streams separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Creates a factory that can be used to create new muxers.
 `options` is an optional `Object` that may have the following properties:
 
 - `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 1048576 - e.g. 1MB)
-- `maxStreamsPerConnection` - a number that defines how many streams are allowed per connection (default: 1024)
+- `maxIncomingStreamsPerConnection` - a number that defines how many incoming streams are allowed per connection (default: 1024)
+- `maxOutgoingStreamsPerConnection` - a number that defines how many outgoing streams are allowed per connection (default: 1024)
 - `maxStreamBufferSize` - a number that defines how large the message buffer is allowed to grow (default: 1024 \* 1024 \* 4 - e.g. 4MB)
 
 ### `const muxer = factory.createStreamMuxer(components, [options])`

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Creates a factory that can be used to create new muxers.
 `options` is an optional `Object` that may have the following properties:
 
 - `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 1048576 - e.g. 1MB)
-- `maxIncomingStreamsPerConnection` - a number that defines how many incoming streams are allowed per connection (default: 1024)
-- `maxOutgoingStreamsPerConnection` - a number that defines how many outgoing streams are allowed per connection (default: 1024)
+- `maxInboundStreams` - a number that defines how many incoming streams are allowed per connection (default: 1024)
+- `maxOutboundStreams` - a number that defines how many outgoing streams are allowed per connection (default: 1024)
 - `maxStreamBufferSize` - a number that defines how large the message buffer is allowed to grow (default: 1024 \* 1024 \* 4 - e.g. 4MB)
 
 ### `const muxer = factory.createStreamMuxer(components, [options])`

--- a/package.json
+++ b/package.json
@@ -141,10 +141,10 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^1.0.0",
-    "@libp2p/interface-connection": "^1.0.1",
+    "@libp2p/components": "^2.0.0",
+    "@libp2p/interface-connection": "^2.0.0",
     "@libp2p/interface-stream-muxer": "^1.0.1",
-    "@libp2p/logger": "^1.1.3",
+    "@libp2p/logger": "^2.0.0",
     "@libp2p/tracked-map": "^1.0.5",
     "abortable-iterator": "^4.0.2",
     "any-signal": "^3.0.0",
@@ -157,7 +157,7 @@
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-stream-muxer-compliance-tests": "^1.0.2",
+    "@libp2p/interface-stream-muxer-compliance-tests": "^2.0.0",
     "@types/varint": "^6.0.0",
     "aegir": "^37.2.0",
     "cborg": "^1.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Components, Initializable } from '@libp2p/components'
-import type { StreamMuxerFactory, StreamMuxerInit } from '@libp2p/interface-stream-muxer'
+import type { StreamMuxer, StreamMuxerFactory, StreamMuxerInit } from '@libp2p/interface-stream-muxer'
 import { MplexStreamMuxer } from './mplex.js'
 
 export interface MplexInit {
@@ -14,7 +14,13 @@ export interface MplexInit {
    * The maximum number of multiplexed streams that can be open at any
    * one time. An attempt to open more than this will throw.
    */
-  maxStreamsPerConnection?: number
+  maxIncomingStreamsPerConnection?: number
+
+  /**
+   * The maximum number of multiplexed streams that can be open at any
+   * one time. An attempt to open more than this will throw.
+   */
+  maxOutgoingStreamsPerConnection?: number
 
   /**
    * Incoming stream messages are buffered until processed by the stream
@@ -33,11 +39,11 @@ export class Mplex implements StreamMuxerFactory, Initializable {
     this._init = init
   }
 
-  init (components: Components) {
+  init (components: Components): void {
     this.components = components
   }
 
-  createStreamMuxer (init: StreamMuxerInit = {}) {
+  createStreamMuxer (init: StreamMuxerInit = {}): StreamMuxer {
     return new MplexStreamMuxer(this.components, {
       ...init,
       ...this._init

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,13 @@ export interface MplexInit {
    * The maximum number of multiplexed streams that can be open at any
    * one time. An attempt to open more than this will throw.
    */
-  maxIncomingStreamsPerConnection?: number
+  maxInboundStreams?: number
 
   /**
    * The maximum number of multiplexed streams that can be open at any
    * one time. An attempt to open more than this will throw.
    */
-  maxOutgoingStreamsPerConnection?: number
+  maxOutboundStreams?: number
 
   /**
    * Incoming stream messages are buffered until processed by the stream

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -18,7 +18,8 @@ import type { MplexInit } from './index.js'
 
 const log = logger('libp2p:mplex')
 
-const MAX_STREAMS_PER_CONNECTION = 1024
+const MAX_STREAMS_INCOMING_STREAMS_PER_CONNECTION = 1024
+const MAX_STREAMS_OUTGOING_STREAMS_PER_CONNECTION = 1024
 const MAX_STREAM_BUFFER_SIZE = 1024 * 1024 * 4 // 4MB
 
 function printMessage (msg: Message) {
@@ -124,10 +125,12 @@ export class MplexStreamMuxer implements StreamMuxer {
   }
 
   _newStream (options: { id: number, name: string, type: 'initiator' | 'receiver', registry: Map<number, MplexStream> }) {
-    const maxStreams = this._init.maxStreamsPerConnection ?? MAX_STREAMS_PER_CONNECTION
+    if (this._streams.initiators.size === (this._init.maxOutgoingStreamsPerConnection ?? MAX_STREAMS_OUTGOING_STREAMS_PER_CONNECTION)) {
+      throw errCode(new Error('To many outgoing streams open'), 'ERR_TOO_MANY_OUTGOING_STREAMS')
+    }
 
-    if ((this._streams.initiators.size + this._streams.receivers.size) === maxStreams) {
-      throw errCode(new Error('To many streams open'), 'ERR_TOO_MANY_STREAMS')
+    if (this._streams.receivers.size === (this._init.maxIncomingStreamsPerConnection ?? MAX_STREAMS_INCOMING_STREAMS_PER_CONNECTION)) {
+      throw errCode(new Error('To many incoming streams open'), 'ERR_TOO_MANY_INCOMING_STREAMS')
     }
 
     const { id, name, type, registry } = options

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -18,8 +18,8 @@ import type { MplexInit } from './index.js'
 
 const log = logger('libp2p:mplex')
 
-const MAX_STREAMS_INCOMING_STREAMS_PER_CONNECTION = 1024
-const MAX_STREAMS_OUTGOING_STREAMS_PER_CONNECTION = 1024
+const MAX_STREAMS_INBOUND_STREAMS_PER_CONNECTION = 1024
+const MAX_STREAMS_OUTBOUND_STREAMS_PER_CONNECTION = 1024
 const MAX_STREAM_BUFFER_SIZE = 1024 * 1024 * 4 // 4MB
 
 function printMessage (msg: Message) {
@@ -125,12 +125,12 @@ export class MplexStreamMuxer implements StreamMuxer {
   }
 
   _newStream (options: { id: number, name: string, type: 'initiator' | 'receiver', registry: Map<number, MplexStream> }) {
-    if (this._streams.initiators.size === (this._init.maxOutgoingStreamsPerConnection ?? MAX_STREAMS_OUTGOING_STREAMS_PER_CONNECTION)) {
-      throw errCode(new Error('To many outgoing streams open'), 'ERR_TOO_MANY_OUTGOING_STREAMS')
+    if (this._streams.initiators.size === (this._init.maxOutboundStreams ?? MAX_STREAMS_OUTBOUND_STREAMS_PER_CONNECTION)) {
+      throw errCode(new Error('To many outgoing streams open'), 'ERR_TOO_MANY_OUTBOUND_STREAMS')
     }
 
-    if (this._streams.receivers.size === (this._init.maxIncomingStreamsPerConnection ?? MAX_STREAMS_INCOMING_STREAMS_PER_CONNECTION)) {
-      throw errCode(new Error('To many incoming streams open'), 'ERR_TOO_MANY_INCOMING_STREAMS')
+    if (this._streams.receivers.size === (this._init.maxInboundStreams ?? MAX_STREAMS_INBOUND_STREAMS_PER_CONNECTION)) {
+      throw errCode(new Error('To many incoming streams open'), 'ERR_TOO_MANY_INBOUND_STREAMS')
     }
 
     const { id, name, type, registry } = options

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -8,7 +8,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { logger } from '@libp2p/logger'
 import type { Message } from './message-types.js'
-import type { Timeline } from '@libp2p/interface-connection'
+import type { StreamTimeline } from '@libp2p/interface-connection'
 import type { Source } from 'it-stream-types'
 import type { MplexStream } from './mplex.js'
 
@@ -41,7 +41,7 @@ export function createStream (options: Options): MplexStream {
   let sinkEnded = false
   let endErr: Error | undefined
 
-  const timeline: Timeline = {
+  const timeline: StreamTimeline = {
     open: Date.now()
   }
 
@@ -58,7 +58,7 @@ export function createStream (options: Options): MplexStream {
     }
 
     if (sinkEnded) {
-      stream.timeline.close = Date.now()
+      stream.stat.timeline.close = Date.now()
 
       if (onEnd != null) {
         onEnd(endErr)
@@ -223,7 +223,12 @@ export function createStream (options: Options): MplexStream {
       onEnd: onSourceEnd
     }),
 
-    timeline,
+    stat: {
+      direction: type === 'initiator' ? 'outbound' : 'inbound',
+      timeline
+    },
+
+    metadata: {},
 
     id: externalId
   }

--- a/test/mplex.spec.ts
+++ b/test/mplex.spec.ts
@@ -12,48 +12,60 @@ import type { Source } from 'it-stream-types'
 import delay from 'delay'
 import pDefer from 'p-defer'
 import { decode } from '../src/decode.js'
+import { pushable } from 'it-pushable'
 
 describe('mplex', () => {
   it('should restrict number of initiator streams per connection', async () => {
-    const maxStreamsPerConnection = 10
+    const maxOutgoingStreamsPerConnection = 10
     const factory = new Mplex({
-      maxStreamsPerConnection
+      maxOutgoingStreamsPerConnection
     })
     const muxer = factory.createStreamMuxer()
 
     // max out the streams for this connection
-    for (let i = 0; i < maxStreamsPerConnection; i++) {
+    for (let i = 0; i < maxOutgoingStreamsPerConnection; i++) {
       muxer.newStream()
     }
 
     // open one more
-    expect(() => muxer.newStream()).to.throw().with.property('code', 'ERR_TOO_MANY_STREAMS')
+    expect(() => muxer.newStream()).to.throw().with.property('code', 'ERR_TOO_MANY_OUTGOING_STREAMS')
   })
 
   it('should restrict number of recipient streams per connection', async () => {
-    const maxStreamsPerConnection = 10
+    const maxIncomingStreamsPerConnection = 10
     const factory = new Mplex({
-      maxStreamsPerConnection
+      maxIncomingStreamsPerConnection
     })
     const muxer = factory.createStreamMuxer()
+    const stream = pushable()
 
     // max out the streams for this connection
-    for (let i = 0; i < maxStreamsPerConnection; i++) {
-      muxer.newStream()
+    for (let i = 0; i < maxIncomingStreamsPerConnection; i++) {
+      const source: NewStreamMessage[] = [{
+        id: i,
+        type: 0,
+        data: uint8ArrayFromString('17')
+      }]
+
+      const data = uint8ArrayConcat(await all(encode(source)))
+
+      stream.push(data)
     }
 
     // simulate a new incoming stream
     const source: NewStreamMessage[] = [{
-      id: 17,
+      id: 11,
       type: 0,
       data: uint8ArrayFromString('17')
     }]
 
     const data = uint8ArrayConcat(await all(encode(source)))
 
-    await muxer.sink([data])
+    stream.push(data)
 
-    await expect(all(muxer.source)).to.eventually.be.rejected.with.property('code', 'ERR_TOO_MANY_STREAMS')
+    await muxer.sink(stream)
+
+    await expect(all(muxer.source)).to.eventually.be.rejected.with.property('code', 'ERR_TOO_MANY_INCOMING_STREAMS')
   })
 
   it('should reset a stream that fills the message buffer', async () => {

--- a/test/mplex.spec.ts
+++ b/test/mplex.spec.ts
@@ -16,31 +16,31 @@ import { pushable } from 'it-pushable'
 
 describe('mplex', () => {
   it('should restrict number of initiator streams per connection', async () => {
-    const maxOutgoingStreamsPerConnection = 10
+    const maxOutboundStreams = 10
     const factory = new Mplex({
-      maxOutgoingStreamsPerConnection
+      maxOutboundStreams
     })
     const muxer = factory.createStreamMuxer()
 
     // max out the streams for this connection
-    for (let i = 0; i < maxOutgoingStreamsPerConnection; i++) {
+    for (let i = 0; i < maxOutboundStreams; i++) {
       muxer.newStream()
     }
 
     // open one more
-    expect(() => muxer.newStream()).to.throw().with.property('code', 'ERR_TOO_MANY_OUTGOING_STREAMS')
+    expect(() => muxer.newStream()).to.throw().with.property('code', 'ERR_TOO_MANY_OUTBOUND_STREAMS')
   })
 
   it('should restrict number of recipient streams per connection', async () => {
-    const maxIncomingStreamsPerConnection = 10
+    const maxInboundStreams = 10
     const factory = new Mplex({
-      maxIncomingStreamsPerConnection
+      maxInboundStreams
     })
     const muxer = factory.createStreamMuxer()
     const stream = pushable()
 
     // max out the streams for this connection
-    for (let i = 0; i < maxIncomingStreamsPerConnection; i++) {
+    for (let i = 0; i < maxInboundStreams; i++) {
       const source: NewStreamMessage[] = [{
         id: i,
         type: 0,
@@ -65,7 +65,7 @@ describe('mplex', () => {
 
     await muxer.sink(stream)
 
-    await expect(all(muxer.source)).to.eventually.be.rejected.with.property('code', 'ERR_TOO_MANY_INCOMING_STREAMS')
+    await expect(all(muxer.source)).to.eventually.be.rejected.with.property('code', 'ERR_TOO_MANY_INBOUND_STREAMS')
   })
 
   it('should reset a stream that fills the message buffer', async () => {


### PR DESCRIPTION
* Updates interfaces
* Returns `StreamMuxer` type
* Adds `maxIncomingStreamsPerConnection` and `maxOutgoingStreamsPerConnection` options to stop lots of incoming streams preventing outgoing streams from being opened

BREAKING CHANGE: updates to simplified connection interface