### PR TITLE
fix: simplify decoder data

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "it-pushable": "^3.0.0",
     "it-stream-types": "^1.0.4",
     "uint8arraylist": "^2.1.1",
-    "uint8arrays": "^3.0.0",
+    "uint8arrays": "^3.1.0",
     "varint": "^6.0.0"
   },
   "devDependencies": {

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -44,7 +44,7 @@ class Encoder {
     if ((msg.type === MessageTypes.NEW_STREAM || msg.type === MessageTypes.MESSAGE_INITIATOR || msg.type === MessageTypes.MESSAGE_RECEIVER) && msg.data != null) {
       return [
         header,
-        msg.data instanceof Uint8Array ? msg.data : msg.data.subarray()
+        msg.data
       ]
     }
 

--- a/src/message-types.ts
+++ b/src/message-types.ts
@@ -1,5 +1,3 @@
-import type { Uint8ArrayList } from 'uint8arraylist'
-
 type INITIATOR_NAME = 'NEW_STREAM' | 'MESSAGE' | 'CLOSE' | 'RESET'
 type RECEIVER_NAME = 'MESSAGE' | 'CLOSE' | 'RESET'
 type NAME = 'NEW_STREAM' | 'MESSAGE_INITIATOR' | 'CLOSE_INITIATOR' | 'RESET_INITIATOR' | 'MESSAGE_RECEIVER' | 'CLOSE_RECEIVER' | 'RESET_RECEIVER'
@@ -41,19 +39,19 @@ export const ReceiverMessageTypes: Record<RECEIVER_NAME, CODE> = Object.freeze({
 export interface NewStreamMessage {
   id: number
   type: MessageTypes.NEW_STREAM
-  data: Uint8Array | Uint8ArrayList
+  data: Uint8Array
 }
 
 export interface MessageReceiverMessage {
   id: number
   type: MessageTypes.MESSAGE_RECEIVER
-  data: Uint8Array | Uint8ArrayList
+  data: Uint8Array
 }
 
 export interface MessageInitiatorMessage {
   id: number
   type: MessageTypes.MESSAGE_INITIATOR
-  data: Uint8Array | Uint8ArrayList
+  data: Uint8Array
 }
 
 export interface CloseReceiverMessage {

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -30,11 +30,11 @@ function printMessage (msg: Message) {
   }
 
   if (msg.type === MessageTypes.NEW_STREAM) {
-    output.data = uint8ArrayToString(msg.data instanceof Uint8Array ? msg.data : msg.data.subarray())
+    output.data = uint8ArrayToString(msg.data)
   }
 
   if (msg.type === MessageTypes.MESSAGE_INITIATOR || msg.type === MessageTypes.MESSAGE_RECEIVER) {
-    output.data = uint8ArrayToString(msg.data instanceof Uint8Array ? msg.data : msg.data.subarray(), 'base16')
+    output.data = uint8ArrayToString(msg.data, 'base16')
   }
 
   return output
@@ -164,10 +164,6 @@ export class MplexStreamMuxer implements StreamMuxer {
         log.trace('%s stream %s send', type, id, printMessage(msg))
       }
 
-      if (msg.type === MessageTypes.NEW_STREAM || msg.type === MessageTypes.MESSAGE_INITIATOR || msg.type === MessageTypes.MESSAGE_RECEIVER) {
-        msg.data = msg.data instanceof Uint8Array ? msg.data : msg.data.subarray()
-      }
-
       this._source.push(msg)
     }
 
@@ -263,7 +259,7 @@ export class MplexStreamMuxer implements StreamMuxer {
         return
       }
 
-      const stream = this._newReceiverStream({ id, name: uint8ArrayToString(message.data instanceof Uint8Array ? message.data : message.data.subarray()) })
+      const stream = this._newReceiverStream({ id, name: uint8ArrayToString(message.data) })
 
       if (this._init.onIncomingStream != null) {
         this._init.onIncomingStream(stream)
@@ -301,7 +297,7 @@ export class MplexStreamMuxer implements StreamMuxer {
         }
 
         // We got data from the remote, push it into our local stream
-        stream.source.push(message.data.subarray())
+        stream.source.push(message.data)
         break
       case MessageTypes.CLOSE_INITIATOR:
       case MessageTypes.CLOSE_RECEIVER:

--- a/test/coder.spec.ts
+++ b/test/coder.spec.ts
@@ -49,7 +49,7 @@ describe('coder', () => {
       data: new Uint8ArrayList(
         uint8ArrayFromString(Math.random().toString()),
         uint8ArrayFromString(Math.random().toString())
-      )
+      ).subarray()
     }]
 
     const data = uint8ArrayConcat(await all(encode(source)))
@@ -58,7 +58,7 @@ describe('coder', () => {
       uint8ArrayConcat([
         uint8ArrayFromString('8801', 'base16'),
         Uint8Array.from([source[0].data.length]),
-        source[0].data instanceof Uint8Array ? source[0].data : source[0].data.slice()
+        source[0].data
       ])
     )
   })


### PR DESCRIPTION
**Motivation**
- Decoder always yield `Uint8Array` so we don't need to handle `Uint8ArrayList` in `mplex.ts`

**Description**
- Use `Uint8Array` consistently in message
- Use new version of `uint8arrays` with `toString/fromString` improvement