### PR TITLE
fix!: emit uint8arraylists for data

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "dependencies": {
     "@libp2p/components": "^2.0.0",
-    "@libp2p/interface-connection": "^2.0.0",
+    "@libp2p/interface-connection": "^3.0.1",
     "@libp2p/interface-stream-muxer": "^2.0.0",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/tracked-map": "^2.0.0",
@@ -161,7 +161,7 @@
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-stream-muxer-compliance-tests": "^3.0.1",
+    "@libp2p/interface-stream-muxer-compliance-tests": "^4.0.0",
     "@types/varint": "^6.0.0",
     "aegir": "^37.2.0",
     "cborg": "^1.8.1",

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -49,7 +49,7 @@ class Decoder {
       }
 
       if (type === MessageTypes.NEW_STREAM || type === MessageTypes.MESSAGE_INITIATOR || type === MessageTypes.MESSAGE_RECEIVER) {
-        msg.data = this._buffer.subarray(offset, offset + length)
+        msg.data = this._buffer.sublist(offset, offset + length)
       }
 
       msgs.push(msg)

--- a/src/message-types.ts
+++ b/src/message-types.ts
@@ -41,19 +41,19 @@ export const ReceiverMessageTypes: Record<RECEIVER_NAME, CODE> = Object.freeze({
 export interface NewStreamMessage {
   id: number
   type: MessageTypes.NEW_STREAM
-  data: Uint8Array | Uint8ArrayList
+  data: Uint8ArrayList
 }
 
 export interface MessageReceiverMessage {
   id: number
   type: MessageTypes.MESSAGE_RECEIVER
-  data: Uint8Array | Uint8ArrayList
+  data: Uint8ArrayList
 }
 
 export interface MessageInitiatorMessage {
   id: number
   type: MessageTypes.MESSAGE_INITIATOR
-  data: Uint8Array | Uint8ArrayList
+  data: Uint8ArrayList
 }
 
 export interface CloseReceiverMessage {

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -16,6 +16,7 @@ import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interface-stream-muxe
 import type { Stream } from '@libp2p/interface-connection'
 import type { MplexInit } from './index.js'
 import anySignal from 'any-signal'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 const log = logger('libp2p:mplex')
 
@@ -41,7 +42,7 @@ function printMessage (msg: Message) {
 }
 
 export interface MplexStream extends Stream {
-  source: Pushable<Uint8Array>
+  source: Pushable<Uint8ArrayList>
 }
 
 interface MplexStreamMuxerInit extends MplexInit, StreamMuxerInit {}
@@ -162,10 +163,6 @@ export class MplexStreamMuxer implements StreamMuxer {
     const send = (msg: Message) => {
       if (log.enabled) {
         log.trace('%s stream %s send', type, id, printMessage(msg))
-      }
-
-      if (msg.type === MessageTypes.NEW_STREAM || msg.type === MessageTypes.MESSAGE_INITIATOR || msg.type === MessageTypes.MESSAGE_RECEIVER) {
-        msg.data = msg.data instanceof Uint8Array ? msg.data : msg.data.subarray()
       }
 
       this._source.push(msg)
@@ -301,7 +298,7 @@ export class MplexStreamMuxer implements StreamMuxer {
         }
 
         // We got data from the remote, push it into our local stream
-        stream.source.push(message.data.subarray())
+        stream.source.push(message.data)
         break
       case MessageTypes.CLOSE_INITIATOR:
       case MessageTypes.CLOSE_RECEIVER:

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -145,7 +145,7 @@ export function createStream (options: Options): MplexStream {
       onSinkEnd(err)
     },
 
-    sink: async (source: Source<Uint8Array>) => {
+    sink: async (source: Source<Uint8ArrayList | Uint8Array>) => {
       if (sinkSunk) {
         throw errCode(new Error('sink already called on stream'), ERR_DOUBLE_SINK)
       }
@@ -164,7 +164,7 @@ export function createStream (options: Options): MplexStream {
 
       try {
         if (type === 'initiator') { // If initiator, open a new stream
-          send({ id, type: InitiatorMessageTypes.NEW_STREAM, data: uint8ArrayFromString(streamName) })
+          send({ id, type: InitiatorMessageTypes.NEW_STREAM, data: new Uint8ArrayList(uint8ArrayFromString(streamName)) })
         }
 
         const uint8ArrayList = new Uint8ArrayList()
@@ -174,13 +174,13 @@ export function createStream (options: Options): MplexStream {
 
           while (uint8ArrayList.length !== 0) {
             if (uint8ArrayList.length <= maxMsgSize) {
-              send({ id, type: Types.MESSAGE, data: uint8ArrayList.subarray() })
+              send({ id, type: Types.MESSAGE, data: uint8ArrayList.sublist() })
               uint8ArrayList.consume(uint8ArrayList.length)
               break
             }
 
             const toSend = uint8ArrayList.length - maxMsgSize
-            send({ id, type: Types.MESSAGE, data: uint8ArrayList.subarray(0, toSend) })
+            send({ id, type: Types.MESSAGE, data: uint8ArrayList.sublist(0, toSend) })
             uint8ArrayList.consume(toSend)
           }
         }

--- a/test/coder.spec.ts
+++ b/test/coder.spec.ts
@@ -13,7 +13,7 @@ import { Uint8ArrayList } from 'uint8arraylist'
 
 describe('coder', () => {
   it('should encode header', async () => {
-    const source: Message[] = [{ id: 17, type: 0, data: uint8ArrayFromString('17') }]
+    const source: Message[] = [{ id: 17, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('17')) }]
 
     const data = uint8ArrayConcat(await all(encode(source)))
 
@@ -32,9 +32,9 @@ describe('coder', () => {
 
   it('should encode several msgs into buffer', async () => {
     const source: Message[] = [
-      { id: 17, type: 0, data: uint8ArrayFromString('17') },
-      { id: 19, type: 0, data: uint8ArrayFromString('19') },
-      { id: 21, type: 0, data: uint8ArrayFromString('21') }
+      { id: 17, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('17')) },
+      { id: 19, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('19')) },
+      { id: 21, type: 0, data: new Uint8ArrayList(uint8ArrayFromString('21')) }
     ]
 
     const data = uint8ArrayConcat(await all(encode(source)))

--- a/test/mplex.spec.ts
+++ b/test/mplex.spec.ts
@@ -13,6 +13,7 @@ import delay from 'delay'
 import pDefer from 'p-defer'
 import { decode } from '../src/decode.js'
 import { pushable } from 'it-pushable'
+import { Uint8ArrayList } from 'uint8arraylist'
 
 describe('mplex', () => {
   it('should restrict number of initiator streams per connection', async () => {
@@ -44,7 +45,7 @@ describe('mplex', () => {
       const source: NewStreamMessage[] = [{
         id: i,
         type: 0,
-        data: uint8ArrayFromString('17')
+        data: new Uint8ArrayList(uint8ArrayFromString('17'))
       }]
 
       const data = uint8ArrayConcat(await all(encode(source)))
@@ -56,7 +57,7 @@ describe('mplex', () => {
     const source: NewStreamMessage[] = [{
       id: 11,
       type: 0,
-      data: uint8ArrayFromString('17')
+      data: new Uint8ArrayList(uint8ArrayFromString('17'))
     }]
 
     const data = uint8ArrayConcat(await all(encode(source)))
@@ -91,7 +92,7 @@ describe('mplex', () => {
       const newStreamMessage: NewStreamMessage = {
         id,
         type: MessageTypes.NEW_STREAM,
-        data: new Uint8Array(1024)
+        data: new Uint8ArrayList(new Uint8Array(1024))
       }
       yield newStreamMessage
 
@@ -101,7 +102,7 @@ describe('mplex', () => {
         const dataMessage: MessageInitiatorMessage = {
           id,
           type: MessageTypes.MESSAGE_INITIATOR,
-          data: new Uint8Array(1024 * 1024)
+          data: new Uint8ArrayList(new Uint8Array(1024 * 1024))
         }
         yield dataMessage
 

--- a/test/restrict-size.spec.ts
+++ b/test/restrict-size.spec.ts
@@ -8,16 +8,17 @@ import drain from 'it-drain'
 import each from 'it-foreach'
 import { Message, MessageTypes } from '../src/message-types.js'
 import { restrictSize } from '../src/restrict-size.js'
+import { Uint8ArrayList } from 'uint8arraylist'
 
 describe('restrict-size', () => {
   it('should throw when size is too big', async () => {
     const maxSize = 32
 
     const input: Message[] = [
-      { id: 0, type: 1, data: await randomBytes(8) },
-      { id: 0, type: 1, data: await randomBytes(maxSize) },
-      { id: 0, type: 1, data: await randomBytes(64) },
-      { id: 0, type: 1, data: await randomBytes(16) }
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(8)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(maxSize)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(64)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(16)) }
     ]
 
     const output: Message[] = []


### PR DESCRIPTION
To make sure there's no chance we end up copying memory to a new
location only to pass it to a stream handler, return `Uint8ArrayList`s
for the `data` property of multiplexed messages.

The stream interface looks like this:

```
Stream extends Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>
```

That is, it's a Duplex whose source emits `Uint8ArrayList`s but the
sink can accept `Uint8ArrayList`s or `Uint8Arrays`.

Depends on:

- [x] https://github.com/libp2p/js-libp2p-interfaces/pull/279

BREAKING CHANGE: mulitplexed streams now emit `Uint8ArrayList`s and not `Uint8Array`s to handle the case for when transports have smaller chunk sizes than the multiplexer