### PR TITLE
feat: close connections when too many streams are opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Creates a factory that can be used to create new muxers.
 - `maxInboundStreams` - a number that defines how many incoming streams are allowed per connection (default: 1024)
 - `maxOutboundStreams` - a number that defines how many outgoing streams are allowed per connection (default: 1024)
 - `maxStreamBufferSize` - a number that defines how large the message buffer is allowed to grow (default: 1024 \* 1024 \* 4 - e.g. 4MB)
+- `maxNewInboundStreamsPerSecond` - if `maxInboundStreams` is reached, close the connection if the remote tries to open more than this many streams per second (default: 10)
 
 ### `const muxer = factory.createStreamMuxer(components, [options])`
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Creates a factory that can be used to create new muxers.
 - `maxInboundStreams` - a number that defines how many incoming streams are allowed per connection (default: 1024)
 - `maxOutboundStreams` - a number that defines how many outgoing streams are allowed per connection (default: 1024)
 - `maxStreamBufferSize` - a number that defines how large the message buffer is allowed to grow (default: 1024 \* 1024 \* 4 - e.g. 4MB)
-- `maxNewInboundStreamsPerSecond` - if `maxInboundStreams` is reached, close the connection if the remote tries to open more than this many streams per second (default: 10)
+- `disconnectThreshold` - if `maxInboundStreams` is reached, close the connection if the remote continues trying to open more than this many streams per second (default: 5)
 
 ### `const muxer = factory.createStreamMuxer(components, [options])`
 

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "it-pipe": "^2.0.3",
     "it-pushable": "^3.1.0",
     "it-stream-types": "^1.0.4",
-    "rate-limiter-flexible": "^2.3.8",
+    "rate-limiter-flexible": "^2.3.9",
     "uint8arraylist": "^2.1.1",
     "uint8arrays": "^3.0.0",
     "varint": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "it-pipe": "^2.0.3",
     "it-pushable": "^3.1.0",
     "it-stream-types": "^1.0.4",
+    "rate-limiter-flexible": "^2.3.8",
     "uint8arraylist": "^2.1.1",
     "uint8arrays": "^3.0.0",
     "varint": "^6.0.0"

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -44,7 +44,7 @@ class Encoder {
     if ((msg.type === MessageTypes.NEW_STREAM || msg.type === MessageTypes.MESSAGE_INITIATOR || msg.type === MessageTypes.MESSAGE_RECEIVER) && msg.data != null) {
       return [
         header,
-        msg.data instanceof Uint8Array ? msg.data : msg.data.subarray()
+        ...(msg.data instanceof Uint8Array ? [msg.data] : msg.data)
       ]
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,28 +6,37 @@ export interface MplexInit {
   /**
    * The maximum size of message that can be sent in one go in bytes.
    * Messages larger than this will be split into multiple smaller
-   * messages.
+   * messages (default: 1MB)
    */
   maxMsgSize?: number
 
   /**
    * The maximum number of multiplexed streams that can be open at any
-   * one time. An attempt to open more than this will throw.
+   * one time. A request to open more than this will have a stream
+   * reset message sent immediately as a response for the newly opened
+   * stream id (default: 1024)
    */
   maxInboundStreams?: number
 
   /**
    * The maximum number of multiplexed streams that can be open at any
-   * one time. An attempt to open more than this will throw.
+   * one time. An attempt to open more than this will throw (default: 1024)
    */
   maxOutboundStreams?: number
 
   /**
    * Incoming stream messages are buffered until processed by the stream
    * handler. If the buffer reaches this size in bytes the stream will
-   * be reset.
+   * be reset (default: 4MB)
    */
   maxStreamBufferSize?: number
+
+  /**
+   * When `maxInboundStreams` is hit, if the remote tries to open more than
+   * this many new multiplexed streams per second the connection will be
+   * closed (default: 10)
+   */
+  maxNewInboundStreamsPerSecond?: number
 }
 
 export class Mplex implements StreamMuxerFactory, Initializable {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,11 @@ export interface MplexInit {
   maxStreamBufferSize?: number
 
   /**
-   * When `maxInboundStreams` is hit, if the remote tries to open more than
-   * this many new multiplexed streams per second the connection will be
-   * closed (default: 10)
+   * When `maxInboundStreams` is hit, if the remote continues try to open
+   * more than this many new multiplexed streams per second the connection
+   * will be closed (default: 5)
    */
-  maxNewInboundStreamsPerSecond?: number
+  disconnectThreshold?: number
 }
 
 export class Mplex implements StreamMuxerFactory, Initializable {

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -24,7 +24,7 @@ const log = logger('libp2p:mplex')
 const MAX_STREAMS_INBOUND_STREAMS_PER_CONNECTION = 1024
 const MAX_STREAMS_OUTBOUND_STREAMS_PER_CONNECTION = 1024
 const MAX_STREAM_BUFFER_SIZE = 1024 * 1024 * 4 // 4MB
-const MAX_NEW_INBOUND_STREAMS_PER_SECOND = 10
+const DISCONNECT_THRESHOLD = 5
 
 function printMessage (msg: Message) {
   const output: any = {
@@ -96,7 +96,7 @@ export class MplexStreamMuxer implements StreamMuxer {
     this.closeController = new AbortController()
 
     this.rateLimiter = new RateLimiterMemory({
-      points: init.maxNewInboundStreamsPerSecond ?? MAX_NEW_INBOUND_STREAMS_PER_SECOND,
+      points: init.disconnectThreshold ?? DISCONNECT_THRESHOLD,
       duration: 1
     })
   }

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -10,6 +10,7 @@ import { toString as uint8ArrayToString } from 'uint8arrays'
 import { trackedMap } from '@libp2p/tracked-map'
 import { logger } from '@libp2p/logger'
 import errCode from 'err-code'
+import { RateLimiterMemory } from 'rate-limiter-flexible'
 import type { Components } from '@libp2p/components'
 import type { Sink } from 'it-stream-types'
 import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interface-stream-muxer'
@@ -23,6 +24,7 @@ const log = logger('libp2p:mplex')
 const MAX_STREAMS_INBOUND_STREAMS_PER_CONNECTION = 1024
 const MAX_STREAMS_OUTBOUND_STREAMS_PER_CONNECTION = 1024
 const MAX_STREAM_BUFFER_SIZE = 1024 * 1024 * 4 // 4MB
+const MAX_NEW_INBOUND_STREAMS_PER_SECOND = 10
 
 function printMessage (msg: Message) {
   const output: any = {
@@ -58,6 +60,7 @@ export class MplexStreamMuxer implements StreamMuxer {
   private readonly _init: MplexStreamMuxerInit
   private readonly _source: { push: (val: Message) => void, end: (err?: Error) => void }
   private readonly closeController: AbortController
+  private readonly rateLimiter: RateLimiterMemory
 
   constructor (components: Components, init?: MplexStreamMuxerInit) {
     init = init ?? {}
@@ -91,6 +94,11 @@ export class MplexStreamMuxer implements StreamMuxer {
      * Close controller
      */
     this.closeController = new AbortController()
+
+    this.rateLimiter = new RateLimiterMemory({
+      points: init.maxNewInboundStreamsPerSecond ?? MAX_NEW_INBOUND_STREAMS_PER_SECOND,
+      duration: 1
+    })
   }
 
   init (components: Components) {}
@@ -101,12 +109,13 @@ export class MplexStreamMuxer implements StreamMuxer {
   get streams () {
     // Inbound and Outbound streams may have the same ids, so we need to make those unique
     const streams: Stream[] = []
-    this._streams.initiators.forEach(stream => {
+    for (const stream of this._streams.initiators.values()) {
       streams.push(stream)
-    })
-    this._streams.receivers.forEach(stream => {
+    }
+
+    for (const stream of this._streams.receivers.values()) {
       streams.push(stream)
-    })
+    }
     return streams
   }
 
@@ -150,7 +159,7 @@ export class MplexStreamMuxer implements StreamMuxer {
   _newStream (options: { id: number, name: string, type: 'initiator' | 'receiver', registry: Map<number, MplexStream> }) {
     const { id, name, type, registry } = options
 
-    log('new %s stream %s %s', type, id, name)
+    log('new %s stream %s %s', type, id)
 
     if (type === 'initiator' && this._streams.initiators.size === (this._init.maxOutboundStreams ?? MAX_STREAMS_OUTBOUND_STREAMS_PER_CONNECTION)) {
       throw errCode(new Error('Too many outbound streams open'), 'ERR_TOO_MANY_OUTBOUND_STREAMS')
@@ -169,7 +178,7 @@ export class MplexStreamMuxer implements StreamMuxer {
     }
 
     const onEnd = () => {
-      log('%s stream %s ended', type, id, name)
+      log('%s stream with id %s and protocol %s ended', type, id, stream.stat.protocol)
       registry.delete(id)
 
       if (this._init.onStreamEnd != null) {
@@ -202,7 +211,7 @@ export class MplexStreamMuxer implements StreamMuxer {
           restrictSize(this._init.maxMsgSize),
           async source => {
             for await (const msg of source) {
-              this._handleIncoming(msg)
+              await this._handleIncoming(msg)
             }
           }
         )
@@ -237,7 +246,7 @@ export class MplexStreamMuxer implements StreamMuxer {
     })
   }
 
-  _handleIncoming (message: Message) {
+  async _handleIncoming (message: Message) {
     const { id, type } = message
 
     if (log.enabled) {
@@ -247,15 +256,26 @@ export class MplexStreamMuxer implements StreamMuxer {
     // Create a new stream?
     if (message.type === MessageTypes.NEW_STREAM) {
       if (this._streams.receivers.size === (this._init.maxInboundStreams ?? MAX_STREAMS_INBOUND_STREAMS_PER_CONNECTION)) {
-        log.error('Too many inbound streams open')
+        log('too many inbound streams open')
 
         // not going to allow this stream, send the reset message manually
         // instead of setting it up just to tear it down
-
         this._source.push({
           id,
           type: MessageTypes.RESET_RECEIVER
         })
+
+        // if we've hit our stream limit, and the remote keeps trying to open
+        // more new streams, if they are doing this very quickly maybe they
+        // are attacking us and we should close the connection
+        try {
+          await this.rateLimiter.consume('new-stream', 1)
+        } catch {
+          log('rate limit hit when opening too many new streams over the inbound stream limit - closing remote connection')
+          // since there's no backpressure in mplex, the only thing we can really do to protect ourselves is close the connection
+          this._source.end(new Error('Too many open streams'))
+          return
+        }
 
         return
       }
@@ -273,7 +293,7 @@ export class MplexStreamMuxer implements StreamMuxer {
     const stream = list.get(id)
 
     if (stream == null) {
-      log('missing stream %s', id)
+      log('missing stream %s for message type %s', id, MessageTypeNames[type])
 
       return
     }

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -8,7 +8,7 @@ describe('compliance', () => {
     async setup () {
       return new Mplex({
         maxInboundStreams: Infinity,
-        maxNewInboundStreamsPerSecond: Infinity
+        disconnectThreshold: Infinity
       })
     },
     async teardown () {}

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -6,7 +6,10 @@ import { Mplex } from '../src/index.js'
 describe('compliance', () => {
   tests({
     async setup () {
-      return new Mplex()
+      return new Mplex({
+        maxInboundStreams: Infinity,
+        maxNewInboundStreamsPerSecond: Infinity
+      })
     },
     async teardown () {}
   })

--- a/test/mplex.spec.ts
+++ b/test/mplex.spec.ts
@@ -36,7 +36,7 @@ describe('mplex', () => {
     const maxInboundStreams = 10
     const factory = new Mplex({
       maxInboundStreams,
-      maxNewInboundStreamsPerSecond: Infinity
+      disconnectThreshold: Infinity
     })
     const muxer = factory.createStreamMuxer()
     const stream = pushable()

--- a/test/mplex.spec.ts
+++ b/test/mplex.spec.ts
@@ -35,7 +35,8 @@ describe('mplex', () => {
   it('should restrict number of recipient streams per connection', async () => {
     const maxInboundStreams = 10
     const factory = new Mplex({
-      maxInboundStreams
+      maxInboundStreams,
+      maxNewInboundStreamsPerSecond: Infinity
     })
     const muxer = factory.createStreamMuxer()
     const stream = pushable()


### PR DESCRIPTION
If we hit the inbound stream limit and the remote peer continues to attempt to open new streams at a rate we consider to be unreasonable, close the connection.

Mplex has no notion of backpressure so this is all we can really do to protect ourselves.