### PR TITLE
fix: remove tracked map as the stats overwrite each other

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "@libp2p/interface-connection": "^3.0.1",
     "@libp2p/interface-stream-muxer": "^2.0.0",
     "@libp2p/logger": "^2.0.0",
-    "@libp2p/tracked-map": "^2.0.0",
     "abortable-iterator": "^4.0.2",
     "any-signal": "^3.0.0",
     "err-code": "^3.0.1",

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -7,7 +7,6 @@ import { restrictSize } from './restrict-size.js'
 import { MessageTypes, MessageTypeNames, Message } from './message-types.js'
 import { createStream } from './stream.js'
 import { toString as uint8ArrayToString } from 'uint8arrays'
-import { trackedMap } from '@libp2p/tracked-map'
 import { logger } from '@libp2p/logger'
 import errCode from 'err-code'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
@@ -71,11 +70,11 @@ export class MplexStreamMuxer implements StreamMuxer {
       /**
        * Stream to ids map
        */
-      initiators: trackedMap<number, MplexStream>({ metrics: components.getMetrics(), component: 'mplex', metric: 'initiatorStreams' }),
+      initiators: new Map<number, MplexStream>(),
       /**
        * Stream to ids map
        */
-      receivers: trackedMap<number, MplexStream>({ metrics: components.getMetrics(), component: 'mplex', metric: 'receiverStreams' })
+      receivers: new Map<number, MplexStream>()
     }
     this._init = init
 


### PR DESCRIPTION
The stats are useless since every connection has a stream muxer but they all record stats to the same keys meaning they overwrite each other.