### PR TITLE
chore: refactor benchmarks for use in the browser

### DIFF
--- a/benchmark/send-and-receive.js
+++ b/benchmark/send-and-receive.js
@@ -1,19 +1,23 @@
 /* eslint-disable no-console */
 'use strict'
 
+/*
+$ node benchmark/send-and-receive.js
+$ npx playwright-test benchmark/send-and-receive.js --runner benchmark
+*/
+
+import Benchmark from 'benchmark'
 import { pipe } from 'it-pipe'
 import { expect } from 'aegir/chai'
-import { itBench, setBenchOpts } from '@dapplion/benchmark'
 import { pushable } from 'it-pushable'
 import { Mplex } from '../dist/src/index.js'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 
 const factory = new Mplex()
 const muxer = factory.createStreamMuxer()
 const stream1 = muxer.newStream('hello')
-console.log('[dialer] new stream id', stream1.id)
 const muxer2 = factory.createStreamMuxer({
   onIncomingStream: async (stream) => {
-    console.log('[listener] muxed stream opened, id:', stream.id)
     await pipe(
       stream,
       function transform (source) {
@@ -40,31 +44,31 @@ const promise = pipe(p, stream1, async function collect (source) {
 })
 
 // typical data of ethereum consensus attestation
-const data = Buffer.from(
+const data = uint8ArrayFromString(
   'e40000000a000000000000000a00000000000000a45c8daa336e17a150300afd4c717313c84f291754c51a378f20958083c5fa070a00000000000000a45c8daa336e17a150300afd4c717313c84f291754c51a378f20958083c5fa070a00000000000000a45c8daa336e17a150300afd4c717313c84f291754c51a378f20958083c5fa0795d2ef8ae4e2b4d1e5b3d5ce47b518e3db2c8c4d082e4498805ac2a686c69f248761b78437db2927470c1e77ede9c18606110faacbcbe4f13052bde7f7eff6aab09edf7bc4929fda2230f943aba2c47b6f940d350cb20c76fad4a8d40e2f3f1f01',
   'hex'
 )
 
-describe('benchmark mplex', function () {
-  this.timeout(0)
-  setBenchOpts({
-    maxMs: 200 * 1000,
-    minMs: 120 * 1000,
-    minRuns: 200
-  })
+const count = 1000
 
-  const count = 1_000
-
-  itBench({
-    id: `send and receive ${count} items`,
-    fn: async () => {
-      for (let i = 0; i < count; i++) {
-        p.push(data)
-      }
-      p.end()
-      const arr = await promise
-      expect(arr.length).to.be.equal(count)
-    },
-    runsFactor: 100
+new Benchmark.Suite()
+  .add('send and receive', async () => {
+    for (let i = 0; i < count; i++) {
+      p.push(data)
+    }
+    p.end()
+    const arr = await promise
+    expect(arr.length).to.be.equal(count)
   })
-})
+  .on('error', (err) => {
+    console.error(err)
+  })
+  .on('cycle', (event) => {
+    console.info(String(event.target))
+  })
+  .on('complete', function () {
+    // @ts-expect-error types are wrong
+    console.info(`Fastest is ${this.filter('fastest').map('name')}`) // eslint-disable-line @typescript-eslint/restrict-template-expressions
+  })
+  // run async
+  .run({ async: true })

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "@libp2p/tracked-map": "^2.0.0",
     "abortable-iterator": "^4.0.2",
     "any-signal": "^3.0.0",
+    "benchmark": "^2.1.4",
     "err-code": "^3.0.1",
     "it-pipe": "^2.0.3",
     "it-pushable": "^3.1.0",
@@ -175,7 +176,6 @@
     "it-map": "^1.0.6",
     "p-defer": "^4.0.0",
     "random-int": "^3.0.0",
-    "@dapplion/benchmark": "^0.2.2",
     "typescript": "^4.7.4"
   },
   "browser": {


### PR DESCRIPTION
Use [benchmark](https://www.npmjs.com/package/benchmark) for running benchmarks so we can run them in the browser too.