### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/benchmark/send-and-receive.js
+++ b/benchmark/send-and-receive.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-'use strict'
 
 /*
 $ node benchmark/send-and-receive.js

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.0",
     "@libp2p/interface-connection": "^3.0.1",
     "@libp2p/interface-stream-muxer": "^3.0.0",
     "@libp2p/logger": "^2.0.0",
@@ -159,11 +158,11 @@
     "it-stream-types": "^1.0.4",
     "rate-limiter-flexible": "^2.3.9",
     "uint8arraylist": "^2.1.1",
-    "uint8arrays": "^3.0.0",
+    "uint8arrays": "^4.0.2",
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-stream-muxer-compliance-tests": "^5.0.0",
+    "@libp2p/interface-stream-muxer-compliance-tests": "^6.0.0",
     "@types/varint": "^6.0.0",
     "aegir": "^37.2.0",
     "cborg": "^1.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { Components, Initializable } from '@libp2p/components'
 import type { StreamMuxer, StreamMuxerFactory, StreamMuxerInit } from '@libp2p/interface-stream-muxer'
 import { MplexStreamMuxer } from './mplex.js'
 
@@ -39,23 +38,28 @@ export interface MplexInit {
   disconnectThreshold?: number
 }
 
-export class Mplex implements StreamMuxerFactory, Initializable {
+export interface MplexComponents {
+
+}
+
+class Mplex implements StreamMuxerFactory {
   public protocol = '/mplex/6.7.0'
   private readonly _init: MplexInit
-  private components: Components = new Components()
+  private readonly _components: MplexComponents
 
-  constructor (init: MplexInit = {}) {
+  constructor (components: MplexComponents, init: MplexInit = {}) {
+    this._components = components
     this._init = init
   }
 
-  init (components: Components): void {
-    this.components = components
-  }
-
   createStreamMuxer (init: StreamMuxerInit = {}): StreamMuxer {
-    return new MplexStreamMuxer(this.components, {
+    return new MplexStreamMuxer(this._components, {
       ...init,
       ...this._init
     })
   }
+}
+
+export function mplex (init: MplexInit = {}): (components?: MplexComponents) => StreamMuxerFactory {
+  return (components: MplexComponents = {}) => new Mplex(components, init)
 }

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -10,11 +10,10 @@ import { toString as uint8ArrayToString } from 'uint8arrays'
 import { logger } from '@libp2p/logger'
 import errCode from 'err-code'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
-import type { Components } from '@libp2p/components'
 import type { Sink } from 'it-stream-types'
 import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interface-stream-muxer'
 import type { Stream } from '@libp2p/interface-connection'
-import type { MplexInit } from './index.js'
+import type { MplexComponents, MplexInit } from './index.js'
 import anySignal from 'any-signal'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
@@ -62,7 +61,7 @@ export class MplexStreamMuxer implements StreamMuxer {
   private readonly closeController: AbortController
   private readonly rateLimiter: RateLimiterMemory
 
-  constructor (components: Components, init?: MplexStreamMuxerInit) {
+  constructor (components: MplexComponents, init?: MplexStreamMuxerInit) {
     init = init ?? {}
 
     this._streamId = 0
@@ -100,8 +99,6 @@ export class MplexStreamMuxer implements StreamMuxer {
       duration: 1
     })
   }
-
-  init (components: Components) {}
 
   /**
    * Returns a Map of streams and their ids

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -1,15 +1,15 @@
 /* eslint-env mocha */
 
 import tests from '@libp2p/interface-stream-muxer-compliance-tests'
-import { Mplex } from '../src/index.js'
+import { mplex } from '../src/index.js'
 
 describe('compliance', () => {
   tests({
     async setup () {
-      return new Mplex({
+      return mplex({
         maxInboundStreams: Infinity,
         disconnectThreshold: Infinity
-      })
+      })()
     },
     async teardown () {}
   })

--- a/test/mplex.spec.ts
+++ b/test/mplex.spec.ts
@@ -2,7 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 5] */
 
 import { expect } from 'aegir/chai'
-import { Mplex } from '../src/index.js'
+import { mplex } from '../src/index.js'
 import { CloseInitiatorMessage, Message, MessageInitiatorMessage, MessageTypes, NewStreamMessage } from '../src/message-types.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
@@ -18,9 +18,9 @@ import { Uint8ArrayList } from 'uint8arraylist'
 describe('mplex', () => {
   it('should restrict number of initiator streams per connection', async () => {
     const maxOutboundStreams = 10
-    const factory = new Mplex({
+    const factory = mplex({
       maxOutboundStreams
-    })
+    })()
     const muxer = factory.createStreamMuxer()
 
     // max out the streams for this connection
@@ -34,10 +34,10 @@ describe('mplex', () => {
 
   it('should restrict number of recipient streams per connection', async () => {
     const maxInboundStreams = 10
-    const factory = new Mplex({
+    const factory = mplex({
       maxInboundStreams,
       disconnectThreshold: Infinity
-    })
+    })()
     const muxer = factory.createStreamMuxer()
     const stream = pushable()
 
@@ -122,9 +122,9 @@ describe('mplex', () => {
     })()
 
     // create the muxer
-    const factory = new Mplex({
+    const factory = mplex({
       maxStreamBufferSize
-    })
+    })()
     const muxer = factory.createStreamMuxer({
       onIncomingStream () {
         // do nothing with the stream so the buffer fills up


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection