### PR TITLE
fix: limit unprocessed message queue size separately to message size

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Creates a factory that can be used to create new muxers.
 `options` is an optional `Object` that may have the following properties:
 
 - `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 4194304 - e.g. 1MB)
-- `maxMessageQueueSize` - a number that limits the size of the unprocessed input buffer (default: )
+- `maxUnprocessedMessageQueueSize` - a number that limits the size of the unprocessed input buffer (default: )
 - `maxInboundStreams` - a number that defines how many incoming streams are allowed per connection (default: 1024)
 - `maxOutboundStreams` - a number that defines how many outgoing streams are allowed per connection (default: 1024)
 - `maxStreamBufferSize` - a number that defines how large the message buffer is allowed to grow (default: 1024 \* 1024 \* 4 - e.g. 4MB)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Creates a factory that can be used to create new muxers.
 
 `options` is an optional `Object` that may have the following properties:
 
-- `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 1048576 - e.g. 1MB)
+- `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 4194304 - e.g. 1MB)
+- `maxMessageQueueSize` - a number that limits the size of the unprocessed input buffer (default: )
 - `maxInboundStreams` - a number that defines how many incoming streams are allowed per connection (default: 1024)
 - `maxOutboundStreams` - a number that defines how many outgoing streams are allowed per connection (default: 1024)
 - `maxStreamBufferSize` - a number that defines how large the message buffer is allowed to grow (default: 1024 \* 1024 \* 4 - e.g. 4MB)

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Creates a factory that can be used to create new muxers.
 
 `options` is an optional `Object` that may have the following properties:
 
-- `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 4194304 - e.g. 1MB)
-- `maxUnprocessedMessageQueueSize` - a number that limits the size of the unprocessed input buffer (default: )
+- `maxMsgSize` - a number that defines how large mplex data messages can be in bytes, if messages are larger than this they will be sent as multiple messages (default: 1048576 - e.g. 1MB)
+- `maxUnprocessedMessageQueueSize` - a number that limits the size of the unprocessed input buffer (default: 4194304 - e.g. 4MB)
 - `maxInboundStreams` - a number that defines how many incoming streams are allowed per connection (default: 1024)
 - `maxOutboundStreams` - a number that defines how many outgoing streams are allowed per connection (default: 1024)
 - `maxStreamBufferSize` - a number that defines how large the message buffer is allowed to grow (default: 1024 \* 1024 \* 4 - e.g. 4MB)

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "it-drain": "^2.0.0",
     "it-foreach": "^1.0.0",
     "it-map": "^2.0.0",
+    "it-to-buffer": "^3.0.0",
     "p-defer": "^4.0.0",
     "random-int": "^3.0.0",
     "typescript": "^4.7.4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export interface MplexInit {
    * than this value an error will be thrown and the connection closed.
    * (default: 4MB)
    */
-  maxMessageQueueSize?: number
+  maxUnprocessedMessageQueueSize?: number
 
   /**
    * The maximum number of multiplexed streams that can be open at any

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,19 @@ export interface MplexInit {
   /**
    * The maximum size of message that can be sent in one go in bytes.
    * Messages larger than this will be split into multiple smaller
-   * messages (default: 1MB)
+   * messages. If we receive a message larger than this an error will
+   * be thrown and the connection closed. (default: 1MB)
    */
   maxMsgSize?: number
+
+  /**
+   * Constrains the size of the unprocessed message queue buffer.
+   * Before messages are deserialized, the raw bytes are buffered to ensure
+   * we have the complete message to deserialized. If the queue gets longer
+   * than this value an error will be thrown and the connection closed.
+   * (default: 4MB)
+   */
+  maxMessageQueueSize?: number
 
   /**
    * The maximum number of multiplexed streams that can be open at any

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -203,7 +203,7 @@ export class MplexStreamMuxer implements StreamMuxer {
       try {
         await pipe(
           source,
-          decode(this._init.maxMsgSize),
+          decode(this._init.maxMsgSize, this._init.maxUnprocessedMessageQueueSize),
           async source => {
             for await (const msg of source) {
               await this._handleIncoming(msg)

--- a/test/restrict-size.spec.ts
+++ b/test/restrict-size.spec.ts
@@ -36,9 +36,10 @@ describe('restrict size', () => {
       )
     } catch (err: any) {
       expect(err).to.have.property('code', 'ERR_MSG_TOO_BIG')
-      expect(output).to.have.length(2)
+      expect(output).to.have.length(3)
       expect(output[0]).to.deep.equal(input[0])
       expect(output[1]).to.deep.equal(input[1])
+      expect(output[2]).to.deep.equal(input[2])
       return
     }
     throw new Error('did not restrict size')

--- a/test/restrict-size.spec.ts
+++ b/test/restrict-size.spec.ts
@@ -10,6 +10,7 @@ import { Message, MessageTypes } from '../src/message-types.js'
 import { encode } from '../src/encode.js'
 import { decode } from '../src/decode.js'
 import { Uint8ArrayList } from 'uint8arraylist'
+import toBuffer from 'it-to-buffer'
 
 describe('restrict size', () => {
   it('should throw when size is too big', async () => {
@@ -59,5 +60,66 @@ describe('restrict size', () => {
       async (source) => await all(source)
     )
     expect(output).to.deep.equal(input)
+  })
+
+  it('should throw when unprocessed message queue size is too big', async () => {
+    const maxMessageSize = 32
+    const maxUnprocessedMessageQueueSize = 64
+
+    const input: Message[] = [
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(16)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(16)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(16)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(16)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(16)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(16)) },
+      { id: 0, type: 1, data: new Uint8ArrayList(randomBytes(16)) }
+    ]
+
+    const output: Message[] = []
+
+    try {
+      await pipe(
+        input,
+        encode,
+        async function * (source) {
+          // make one big buffer
+          yield toBuffer(source)
+        },
+        decode(maxMessageSize, maxUnprocessedMessageQueueSize),
+        (source) => each(source, chunk => {
+          output.push(chunk)
+        }),
+        async (source) => await drain(source)
+      )
+    } catch (err: any) {
+      expect(err).to.have.property('code', 'ERR_MSG_QUEUE_TOO_BIG')
+      expect(output).to.have.length(0)
+      return
+    }
+    throw new Error('did not restrict size')
+  })
+
+  it('should throw when unprocessed message queue size is too big because of garbage', async () => {
+    const maxMessageSize = 32
+    const maxUnprocessedMessageQueueSize = 64
+    const input = randomBytes(maxUnprocessedMessageQueueSize + 1)
+    const output: Message[] = []
+
+    try {
+      await pipe(
+        [input],
+        decode(maxMessageSize, maxUnprocessedMessageQueueSize),
+        (source) => each(source, chunk => {
+          output.push(chunk)
+        }),
+        async (source) => await drain(source)
+      )
+    } catch (err: any) {
+      expect(err).to.have.property('code', 'ERR_MSG_QUEUE_TOO_BIG')
+      expect(output).to.have.length(0)
+      return
+    }
+    throw new Error('did not restrict size')
   })
 })


### PR DESCRIPTION
It's possible to receive lots of small messages in one buffer that can be larger than the max message size, so limit the unprocessed message queue size separately from the max message size.