### PR TITLE
chore: replace err-code with CodeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,11 +149,11 @@
   "dependencies": {
     "@libp2p/interface-connection": "^3.0.1",
     "@libp2p/interface-stream-muxer": "^3.0.0",
+    "@libp2p/interfaces": "^3.2.0",
     "@libp2p/logger": "^2.0.0",
     "abortable-iterator": "^4.0.2",
     "any-signal": "^3.0.0",
     "benchmark": "^2.1.4",
-    "err-code": "^3.0.1",
     "it-batched-bytes": "^1.0.0",
     "it-pushable": "^3.1.0",
     "it-stream-types": "^1.0.4",

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -6,7 +6,7 @@ import { MessageTypes, MessageTypeNames, Message } from './message-types.js'
 import { createStream } from './stream.js'
 import { toString as uint8ArrayToString } from 'uint8arrays'
 import { logger } from '@libp2p/logger'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
 import type { Sink } from 'it-stream-types'
 import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interface-stream-muxer'
@@ -157,7 +157,7 @@ export class MplexStreamMuxer implements StreamMuxer {
     log('new %s stream %s', type, id)
 
     if (type === 'initiator' && this._streams.initiators.size === (this._init.maxOutboundStreams ?? MAX_STREAMS_OUTBOUND_STREAMS_PER_CONNECTION)) {
-      throw errCode(new Error('Too many outbound streams open'), 'ERR_TOO_MANY_OUTBOUND_STREAMS')
+      throw new CodeError('Too many outbound streams open', 'ERR_TOO_MANY_OUTBOUND_STREAMS')
     }
 
     if (registry.has(id)) {
@@ -303,7 +303,7 @@ export class MplexStreamMuxer implements StreamMuxer {
           })
 
           // Inform the stream consumer they are not fast enough
-          const error = errCode(new Error('Input buffer full - increase Mplex maxBufferSize to accommodate slow consumers'), 'ERR_STREAM_INPUT_BUFFER_FULL')
+          const error = new CodeError('Input buffer full - increase Mplex maxBufferSize to accommodate slow consumers', 'ERR_STREAM_INPUT_BUFFER_FULL')
           stream.abort(error)
 
           return

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,6 +1,6 @@
 import { abortableSource } from 'abortable-iterator'
 import { pushable } from 'it-pushable'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import { MAX_MSG_SIZE } from './decode.js'
 import { anySignal } from 'any-signal'
 import { InitiatorMessageTypes, ReceiverMessageTypes } from './message-types.js'
@@ -143,7 +143,7 @@ export function createStream (options: Options): MplexStream {
 
     // Close immediately for reading and writing (remote error)
     reset: () => {
-      const err = errCode(new Error('stream reset'), ERR_STREAM_RESET)
+      const err = new CodeError('stream reset', ERR_STREAM_RESET)
       resetController.abort()
       streamSource.end(err)
       onSinkEnd(err)
@@ -151,13 +151,13 @@ export function createStream (options: Options): MplexStream {
 
     sink: async (source: Source<Uint8ArrayList | Uint8Array>) => {
       if (sinkSunk) {
-        throw errCode(new Error('sink already called on stream'), ERR_DOUBLE_SINK)
+        throw new CodeError('sink already called on stream', ERR_DOUBLE_SINK)
       }
 
       sinkSunk = true
 
       if (sinkEnded) {
-        throw errCode(new Error('stream closed for writing'), ERR_SINK_ENDED)
+        throw new CodeError('stream closed for writing', ERR_SINK_ENDED)
       }
 
       source = abortableSource(source, anySignal([


### PR DESCRIPTION
Replaces [err-code](https://github.com/IndigoUnited/js-err-code/blob/master/index.js) with [CodeError](https://github.com/libp2p/js-libp2p-interfaces/pull/314)

Related: [js-libp2p#1269](https://github.com/libp2p/js-libp2p/issues/1269)

Changes

- removes err-code from dependencies
- adds @libp2p/interfaces@3.2.0 to dependencies
- uses CodeError in place of err-code
