### PR TITLE
deps(dev): Upgrade aegir to 38.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,9 +165,10 @@
   "devDependencies": {
     "@libp2p/interface-stream-muxer-compliance-tests": "^6.0.0",
     "@types/varint": "^6.0.0",
-    "aegir": "^37.2.0",
+    "aegir": "^38.1.7",
     "cborg": "^1.8.1",
     "delay": "^5.0.0",
+    "eslint-plugin-etc": "^2.0.2",
     "iso-random-stream": "^2.0.2",
     "it-all": "^2.0.0",
     "it-drain": "^2.0.0",
@@ -177,7 +178,7 @@
     "it-to-buffer": "^3.0.0",
     "p-defer": "^4.0.0",
     "random-int": "^3.0.0",
-    "typescript": "^5.0.2"
+    "typescript": "4.9.5"
   },
   "browser": {
     "./dist/src/alloc-unsafe.js": "./dist/src/alloc-unsafe-browser.js"

--- a/package.json
+++ b/package.json
@@ -177,8 +177,7 @@
     "it-pipe": "^2.0.3",
     "it-to-buffer": "^3.0.0",
     "p-defer": "^4.0.0",
-    "random-int": "^3.0.0",
-    "typescript": "4.9.5"
+    "random-int": "^3.0.0"
   },
   "browser": {
     "./dist/src/alloc-unsafe.js": "./dist/src/alloc-unsafe-browser.js"

--- a/src/alloc-unsafe-browser.ts
+++ b/src/alloc-unsafe-browser.ts
@@ -1,3 +1,3 @@
-export function allocUnsafe (size: number) {
+export function allocUnsafe (size: number): Uint8Array {
   return new Uint8Array(size)
 }

--- a/src/alloc-unsafe.ts
+++ b/src/alloc-unsafe.ts
@@ -1,3 +1,3 @@
-export function allocUnsafe (size: number) {
+export function allocUnsafe (size: number): Buffer {
   return Buffer.allocUnsafe(size)
 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -25,7 +25,7 @@ export class Decoder {
     this._maxUnprocessedMessageQueueSize = maxUnprocessedMessageQueueSize
   }
 
-  write (chunk: Uint8Array) {
+  write (chunk: Uint8Array): Message[] {
     if (chunk == null || chunk.length === 0) {
       return []
     }
@@ -109,7 +109,12 @@ export class Decoder {
 const MSB = 0x80
 const REST = 0x7F
 
-function readVarInt (buf: Uint8ArrayList, offset: number = 0) {
+export interface ReadVarIntResult {
+  value: number
+  offset: number
+}
+
+function readVarInt (buf: Uint8ArrayList, offset: number = 0): ReadVarIntResult {
   let res = 0
   let shift = 0
   let counter = offset

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -56,7 +56,7 @@ const encoder = new Encoder()
 /**
  * Encode and yield one or more messages
  */
-export async function * encode (source: Source<Message[]>, minSendBytes: number = 0) {
+export async function * encode (source: Source<Message[]>, minSendBytes: number = 0): AsyncGenerator<Uint8Array, void, undefined> {
   if (minSendBytes == null || minSendBytes === 0) {
     // just send the messages
     for await (const messages of source) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -47,7 +47,7 @@ export function createStream (options: Options): MplexStream {
     open: Date.now()
   }
 
-  const onSourceEnd = (err?: Error) => {
+  const onSourceEnd = (err?: Error): void => {
     if (sourceEnded) {
       return
     }
@@ -68,7 +68,7 @@ export function createStream (options: Options): MplexStream {
     }
   }
 
-  const onSinkEnd = (err?: Error) => {
+  const onSinkEnd = (err?: Error): void => {
     if (sinkEnded) {
       return
     }

--- a/test/fixtures/utils.ts
+++ b/test/fixtures/utils.ts
@@ -1,10 +1,16 @@
 import { Message, MessageTypes } from '../../src/message-types.js'
 
-export function messageWithBytes (msg: Message) {
+export type MessageWithBytes = {
+  [k in keyof Message]: Message[k]
+} & {
+  data: Uint8Array
+}
+
+export function messageWithBytes (msg: Message): Message | MessageWithBytes {
   if (msg.type === MessageTypes.NEW_STREAM || msg.type === MessageTypes.MESSAGE_INITIATOR || msg.type === MessageTypes.MESSAGE_RECEIVER) {
     return {
       ...msg,
-      data: msg.data.slice() // convert Uint8ArrayList to Buffer
+      data: msg.data.slice() // convert Uint8ArrayList to Unint8Array
     }
   }
 

--- a/test/fixtures/utils.ts
+++ b/test/fixtures/utils.ts
@@ -10,7 +10,7 @@ export function messageWithBytes (msg: Message): Message | MessageWithBytes {
   if (msg.type === MessageTypes.NEW_STREAM || msg.type === MessageTypes.MESSAGE_INITIATOR || msg.type === MessageTypes.MESSAGE_RECEIVER) {
     return {
       ...msg,
-      data: msg.data.slice() // convert Uint8ArrayList to Unint8Array
+      data: msg.data.slice() // convert Uint8ArrayList to Uint8Array
     }
   }
 

--- a/test/restrict-size.spec.ts
+++ b/test/restrict-size.spec.ts
@@ -33,7 +33,7 @@ describe('restrict size', () => {
         (source) => each(source, chunk => {
           output.push(chunk)
         }),
-        async (source) => await drain(source)
+        async (source) => { await drain(source) }
       )
     } catch (err: any) {
       expect(err).to.have.property('code', 'ERR_MSG_TOO_BIG')
@@ -90,7 +90,7 @@ describe('restrict size', () => {
         (source) => each(source, chunk => {
           output.push(chunk)
         }),
-        async (source) => await drain(source)
+        async (source) => { await drain(source) }
       )
     } catch (err: any) {
       expect(err).to.have.property('code', 'ERR_MSG_QUEUE_TOO_BIG')
@@ -113,7 +113,7 @@ describe('restrict size', () => {
         (source) => each(source, chunk => {
           output.push(chunk)
         }),
-        async (source) => await drain(source)
+        async (source) => { await drain(source) }
       )
     } catch (err: any) {
       expect(err).to.have.property('code', 'ERR_MSG_QUEUE_TOO_BIG')


### PR DESCRIPTION
Also reverting typescript to `4.9.5` because a3590af093dee73c873aef1539bc8d81b0d61b08 upgraded it, but [aegir depends on eslint-plugin-etc](https://github.com/ipfs/aegir/blob/17f7230c65f6227d2d6d9a73921e7e9034364ebd/package.json#L260) ( [as well as eslint-config-ipfs](https://github.com/ipfs/eslint-config-ipfs/blob/main/package.json#L24) which also depends on `eslint-plugin-etc`) which is incompatible with TS5 atm https://github.com/cartant/eslint-plugin-etc/issues/53.