### PR TITLE
deps!: update to new stream type deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 node_modules
 package-lock.json
 yarn.lock
+.vscode

--- a/package.json
+++ b/package.json
@@ -147,23 +147,23 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "@libp2p/interface-connection": "^4.0.0",
-    "@libp2p/interface-stream-muxer": "^3.0.0",
+    "@libp2p/interface-connection": "^5.0.0",
+    "@libp2p/interface-stream-muxer": "^4.0.0",
     "@libp2p/interfaces": "^3.2.0",
     "@libp2p/logger": "^2.0.0",
     "abortable-iterator": "^4.0.2",
     "any-signal": "^4.0.1",
     "benchmark": "^2.1.4",
-    "it-batched-bytes": "^1.0.0",
+    "it-batched-bytes": "^2.0.2",
     "it-pushable": "^3.1.0",
-    "it-stream-types": "^1.0.4",
+    "it-stream-types": "^2.0.1",
     "rate-limiter-flexible": "^2.3.9",
     "uint8arraylist": "^2.1.1",
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-stream-muxer-compliance-tests": "^6.0.0",
+    "@libp2p/interface-stream-muxer-compliance-tests": "^7.0.0",
     "@types/varint": "^6.0.0",
     "aegir": "^38.1.7",
     "cborg": "^1.8.1",

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -25,7 +25,7 @@ export class Decoder {
     this._maxUnprocessedMessageQueueSize = maxUnprocessedMessageQueueSize
   }
 
-  write (chunk: Uint8Array): Message[] {
+  write (chunk: Uint8Array | Uint8ArrayList): Message[] {
     if (chunk == null || chunk.length === 0) {
       return []
     }

--- a/src/mplex.ts
+++ b/src/mplex.ts
@@ -8,7 +8,7 @@ import { toString as uint8ArrayToString } from 'uint8arrays'
 import { logger } from '@libp2p/logger'
 import { CodeError } from '@libp2p/interfaces/errors'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
-import type { Sink } from 'it-stream-types'
+import type { Sink, Source } from 'it-stream-types'
 import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interface-stream-muxer'
 import type { Stream } from '@libp2p/interface-connection'
 import type { MplexInit } from './index.js'
@@ -49,8 +49,8 @@ interface MplexStreamMuxerInit extends MplexInit, StreamMuxerInit {}
 export class MplexStreamMuxer implements StreamMuxer {
   public protocol = '/mplex/6.7.0'
 
-  public sink: Sink<Uint8Array>
-  public source: AsyncIterable<Uint8Array>
+  public sink: Sink<Source<Uint8ArrayList | Uint8Array>, Promise<void>>
+  public source: AsyncGenerator<Uint8Array>
 
   private _streamId: number
   private readonly _streams: { initiators: Map<number, MplexStream>, receivers: Map<number, MplexStream> }
@@ -190,8 +190,8 @@ export class MplexStreamMuxer implements StreamMuxer {
    * Creates a sink with an abortable source. Incoming messages will
    * also have their size restricted. All messages will be varint decoded.
    */
-  _createSink (): Sink<Uint8Array> {
-    const sink: Sink<Uint8Array> = async source => {
+  _createSink (): Sink<Source<Uint8ArrayList | Uint8Array>, Promise<void>> {
+    const sink: Sink<Source<Uint8ArrayList | Uint8Array>, Promise<void>> = async source => {
       const signal = anySignal([this.closeController.signal, this._init.signal])
 
       try {


### PR DESCRIPTION
libp2p streams are now explicit about the types of sync/sources they provide, showing that they are `AsyncGenerator`s and not just `AsyncIterable`s.

BREAKING CHANGE: the type of the source/sink properties have changed