### PR TITLE
fix: use abstract stream class from muxer interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     "aegir": "^39.0.7",
     "cborg": "^1.8.1",
     "delay": "^5.0.0",
-    "eslint-plugin-etc": "^2.0.2",
     "iso-random-stream": "^2.0.2",
     "it-all": "^3.0.1",
     "it-drain": "^3.0.1",


### PR DESCRIPTION
Reuse abstract stream class that defines the logic for closing streams
instead of duplicating here and elsewhere.